### PR TITLE
npm isn't able to install nodeunit due to incorrect path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A simple unit testing tool based on the node.js assert module.
 
 __Contributors__
 
-* [gerad](http://github.com/gerad) - command-line tool
 * [sstephenson](http://github.com/sstephenson) - coffee-script support
 * and thanks to [cjohansen](http://github.com/cjohansen) for input and advice
   on implementing setUp and tearDown functions. See

--- a/package.json
+++ b/package.json
@@ -13,5 +13,5 @@
     , "url" : "http://github.com/caolan/nodeunit/raw/master/LICENSE"
     }
   ]
- , "bin" : { "nodeunit" : "./lib/testrunner" }
+ , "bin" : { "nodeunit" : "./lib/testrunner.js" }
 }


### PR DESCRIPTION
it looks like when you're installing a binary you need to give npm the js extension...

I was getting this error:
    $ npm install nodeunit
    npm info it worked if it ends with ok
    npm info version 0.2.0
    npm info install nodeunit@0.2.0
    npm ERR! failed to link bins
    npm ERR! install failed Error: ENOENT, No such file or directory '/usr/local/lib/node/.npm/nodeunit/0.2.0/package/lib/testrunner'
    npm ERR! install failed     at node.js:757:9
    npm info install failed rollback
    npm info not installed nodeunit,0.2.0
    npm info install failed rolled back
    npm ERR! Error: ENOENT, No such file or directory '/usr/local/lib/node/.npm/nodeunit/0.2.0/package/lib/testrunner'
    npm ERR!     at node.js:757:9
    npm ERR! try running: 'npm help install'
    npm ERR! Report this _entire_ log at http://github.com/isaacs/npm/issues
    npm ERR! or email

The minor tweak I made seems to have fixed it.
