### PR TITLE
Print undone test

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -12,6 +12,7 @@ var nodeunit = require('../nodeunit'),
     utils = require('../utils'),
     fs = require('fs'),
     sys = require('sys'),
+    track = require('../track').track,
     path = require('path');
     AssertionError = require('../assert').AssertionError;
 
@@ -62,6 +63,8 @@ exports.run = function (files, options) {
             sys.puts('\n' + bold(name));
         },
         testDone: function (name, assertions) {
+            track.remove(name);
+            
             if (!assertions.failures()) {
                 sys.puts('✔ ' + name);
             }
@@ -105,6 +108,9 @@ exports.run = function (files, options) {
             setTimeout(function () {
                 process.reallyExit(assertions.failures());
             }, 10);
+        },
+        testStart: function(name) {
+            track.put(name);
         }
     });
 };

--- a/lib/track.js
+++ b/lib/track.js
@@ -1,0 +1,25 @@
+/*!
+ * Simple util module to track tests. Adds a process.exit hook to print the undone tests.
+ */
+var sys = require('sys');
+var track = {
+    names : {},
+    put : function (testname) {
+        this.names[testname] = testname;
+    },
+    remove : function (testname) {
+        delete this.names[testname];
+    },
+    printnames : function () {        
+        for(i in this.names) {
+            sys.puts(i)
+        }
+    }
+};
+
+process.on('exit', function() {
+    sys.puts('Undone tests (or their setups/teardowns): '); 
+    track.printnames(); 
+});
+
+exports.track = track;


### PR DESCRIPTION
Simple util module to track tests. Adds a process.exit hook to print the undone tests.
To test it just uncomment a test.done() call. ;-)

Very simple indeed. But as far as I can see it works.
