### PR TITLE
Allow nodeunit to run tests in a dir and recursively inside its child dirs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,8 @@ var async = require('../deps/async'),
     fs = require('fs'),
     sys = require('sys'),
     Script = process.binding('evals').Script,
-    http = require('http');
+    http = require('http'),
+    path = require('path');
 
 
 /**
@@ -53,31 +54,42 @@ exports.modulePaths = function (paths, callback) {
                 return cb(null, [p]);
             }
             if (stats.isDirectory()) {
-                fs.readdir(p, function (err, files) {
-                    if (err) {
-                        return cb(err);
-                    }
+                var files = exports.readDirRecursive(p);
 
-                    // filter out any filenames with unsupported extensions
-                    var modules = files.filter(function (filename) {
-                        return extensionPattern.exec(filename);
-                    });
-
-                    // remove extension from module name and prepend the
-                    // directory path
-                    var fullpaths = modules.map(function (filename) {
-                        var mod_name = filename.replace(extensionPattern, '');
-                        return [p, mod_name].join('/');
-                    });
-
-                    // sort filenames here, because Array.map changes order
-                    fullpaths.sort();
-
-                    cb(null, fullpaths);
+                // filter out any filenames with unsupported extensions
+                var modules = files.filter(function (filename) {
+                    return extensionPattern.exec(filename);
                 });
+
+                // remove extension from module name and prepend the
+                // directory path
+                var fullpaths = modules.map(function (filename) {
+                    var mod_name = filename.replace(extensionPattern, '');
+                    return [p, mod_name].join('/');
+                });
+
+                // sort filenames here, because Array.map changes order
+                fullpaths.sort();
+
+                cb(null, fullpaths);
             }
         });
     }, callback);
+};
+
+exports.readDirRecursive = function(dir) {
+    var list = [];
+    fs.readdirSync(dir).forEach(function(entityName) {
+        var entityPath = path.join(dir, entityName);
+        if ( fs.statSync(entityPath).isDirectory() ) {
+            exports.readDirRecursive(entityPath).forEach(function(file) {
+                list.push(path.join(entityName, file));
+            });
+        } else {
+            list.push(entityName);
+        }
+    });
+    return list;
 };
 
 /**


### PR DESCRIPTION
I'm using nodeunit in a project and i'm very happy with it, but my collection of test modules is going to be enough big to convince me to organize then in sub-directories. I start to do this, but i discover that "nodeunit test" command will not to run tests inside "test/helpers" or "test/models", so i made a patch to make util.modulePaths() to get it recursively to nodeunit.runFiles().

I don't see why not to work recursively, so i think that is the better default action.

I also made it with synchronous fileSystem methods because the testing action is not paralleled and the asynchronous code to do this is crazily more complex. :-)