### PR TITLE
support RegExp object in deepEqual

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -165,6 +165,14 @@ function _deepEqual(actual, expected) {
   } else if (actual instanceof Date && expected instanceof Date) {
     return actual.getTime() === expected.getTime();
 
+  // 7.2.1 If the expcted value is a RegExp object, the actual value is
+  // equivalent if it is also a RegExp object that refers to the same source and options
+  } else if (actual instanceof RegExp && expected instanceof RegExp) {
+    return actual.source === expected.source &&
+           actual.global === expected.global &&
+           actual.ignoreCase === expected.ignoreCase &&
+           actual.multiline === expected.multiline;
+
   // 7.3. Other pairs that do not both pass typeof value == "object",
   // equivalence is determined by ==.
   } else if (typeof actual != 'object' && typeof expected != 'object') {


### PR DESCRIPTION
There are some trouble in test for object including RegExp object, such as {"a": /hoge/}.

exports["regexp"] = function(test){
  test.deepEqual(/hoge/, /hoge/,'regexp test');
  test.done();
}
# 

$ nodeunit test
AssertionError: { a: /hoge/ } deepEqual { a: /hoge/ }
