### PR TITLE
Allow to add external assertions

### DIFF
--- a/lib/nodeunit.js
+++ b/lib/nodeunit.js
@@ -13,6 +13,7 @@ var async = require('../deps/async'),
     utils = require('./utils'),
     core = require('./core'),
     reporters = require('./reporters'),
+    assert = require('./assert'),
     path = require('path');
 
 
@@ -23,6 +24,7 @@ var async = require('../deps/async'),
 exports.types = types;
 exports.utils = utils;
 exports.reporters = reporters;
+exports.assert = assert;
 
 // backwards compatibility
 exports.testrunner = {


### PR DESCRIPTION
Hi guys! Thanks for the great testing tool.

It would be great if you publish contents of assertion module (lib/assert.js) as part of nodeunit package. So, I would be able to write something like this:

```
var assert = require('nodeunit').assert;
assert.myAwesomeAssertion = function (...) {
    if (...) assert.fail(...);
};
```

I want to use nodeunit as built-in testing solution for RailwayJS apps. For that purpose I have created few additional assertions to simplify controllers, routes ans views testing. There is only one problem: I should write this awful code to extend assertions module:

```
var assert = require(require.resolve('nodeunit').replace(/index\.js$/, 'lib/assert'));
```

I really want to replace this code with

```
var assert = require('nodeunit').assert;
```

Thanks!
