### PR TITLE
Return nonzero exit status code in case of a test failure

### DIFF
--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -117,4 +117,9 @@ if (reporter_file in builtin_reporters) {
 else {
     testrunner = require(reporter_file);
 }
-testrunner.run(files, options);
+
+testrunner.run(files, options, function(err) {
+    if (err) {
+        process.exit(1);
+    }
+});

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -29,7 +29,7 @@ exports.info = "Default tests reporter";
  * @api public
  */
 
-exports.run = function (files, options) {
+exports.run = function (files, options, callback) {
 
     if (!options) {
         // load default options
@@ -115,6 +115,8 @@ exports.run = function (files, options) {
                    ' assertions (' + assertions.duration + 'ms)'
                 );
             }
+
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         },
         testStart: function(name) {
             tracker.put(name);

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -27,7 +27,7 @@ exports.info = "Report tests result as HTML";
  * @api public
  */
 
-exports.run = function (files, options) {
+exports.run = function (files, options, callback) {
 
     var start = new Date().getTime();
     var paths = files.map(function (p) {
@@ -101,7 +101,9 @@ exports.run = function (files, options) {
                 );
             }
             console.log('</body>');
+            console.log('</html>');
+
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         }
     });
-
 };

--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -175,9 +175,9 @@ exports.run = function (files, opts, callback) {
                         }
                     });
 
+                    if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
                 });
             });
-
         }
     });
 }

--- a/lib/reporters/minimal.js
+++ b/lib/reporters/minimal.js
@@ -27,7 +27,7 @@ exports.info = "Pretty minimal output";
  * @api public
  */
 
-exports.run = function (files, options) {
+exports.run = function (files, options, callback) {
 
     if (!options) {
         // load default options
@@ -107,6 +107,8 @@ exports.run = function (files, options) {
                     ' assertions (' + assertions.duration + 'ms)'
                 );
             }
+
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         }
     });
 };

--- a/lib/reporters/skip_passed.js
+++ b/lib/reporters/skip_passed.js
@@ -27,7 +27,7 @@ exports.info = "Skip passed tests output";
  * @api public
  */
 
-exports.run = function (files, options) {
+exports.run = function (files, options, callback) {
 
     if (!options) {
         // load default options
@@ -100,6 +100,8 @@ exports.run = function (files, options) {
                     ' assertions (' + assertions.duration + 'ms)'
                 );
             }
+
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         }
     });
 };


### PR DESCRIPTION
Nodeunit always returns an exit status 0, disregarding if there are failing tests. This troubles my continuous integration system (Jenkins) which performs a build and runs my tests. Jenkins verifies if the commands it executes in the build return a nonzero status code, which means the execution encountered problems. Now I need to grep the output to check for failures and mark my build as failed.
