### PR TITLE
Added 'complete' event to nodeunit

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -139,6 +139,7 @@ exports.runModule = function (name, mod, opt, callback) {
         var end = new Date().getTime();
         var assertion_list = types.assertionList(a_list, end - start);
         options.moduleDone(name, assertion_list);
+        require('./nodeunit').complete();
         callback(null, a_list);
     });
 };

--- a/lib/nodeunit.js
+++ b/lib/nodeunit.js
@@ -14,12 +14,15 @@ var async = require('../deps/async'),
     core = require('./core'),
     reporters = require('./reporters'),
     assert = require('./assert'),
-    path = require('path');
+    path = require('path')
+    events = require('events');
 
 
 /**
  * Export sub-modules.
  */
+
+exports = new events.EventEmitter();
 
 exports.types = types;
 exports.utils = utils;
@@ -80,3 +83,10 @@ exports.runFiles = function (paths, opt) {
     });
 
 };
+
+exports.complete = function()
+{
+	exports.emit('complete');
+};
+
+module.exports = exports;


### PR DESCRIPTION
This event is fired when all tests are done to let people close remote connections and avoid the test runner hanging at the end. Here's how to use:

```
module.exports = {
    ... your tests
};

require('nodeunit').on('complete', function()
{
    ... close your connections
});
```
