### PR TITLE
Add support for callback to retrieve result from reporters

### DIFF
--- a/lib/reporters/browser.js
+++ b/lib/reporters/browser.js
@@ -114,6 +114,8 @@ exports.run = function (modules, options) {
                 assertions.passes() + '</span> assertions of ' +
                 '<span class="all">' + assertions.length + '<span> passed, ' +
                 assertions.failures() + ' failed.';
+            
+            if (options.done) options.done(assertions, end);
         }
     });
 };

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -114,7 +114,8 @@ exports.run = function (files, options) {
                    '\n' + bold(ok('OK: ')) + assertions.length +
                    ' assertions (' + assertions.duration + 'ms)'
                 );
-            }
+            };
+            if (options.done) options.done(assertions, end);
         },
         testStart: function(name) {
             tracker.put(name);

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -101,6 +101,8 @@ exports.run = function (files, options) {
                 );
             }
             console.log('</body>');
+            
+            if (options.done) options.done(assertions, end);
         }
     });
 

--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -177,7 +177,8 @@ exports.run = function (files, opts, callback) {
 
                 });
             });
-
+          
+            if (options.done) options.done(assertions, end);
         }
     });
 }

--- a/lib/reporters/minimal.js
+++ b/lib/reporters/minimal.js
@@ -106,7 +106,8 @@ exports.run = function (files, options) {
                     '\n' + bold(green('OK: ')) + assertions.length +
                     ' assertions (' + assertions.duration + 'ms)'
                 );
-            }
+            };
+            if (options.done) options.done(assertions, end);
         }
     });
 };

--- a/lib/reporters/skip_passed.js
+++ b/lib/reporters/skip_passed.js
@@ -99,7 +99,8 @@ exports.run = function (files, options) {
                     '\n' + bold(ok('OK: ')) + assertions.length +
                     ' assertions (' + assertions.duration + 'ms)'
                 );
-            }
+            };
+            if (options.done) options.done(assertions, end);
         }
     });
 };


### PR DESCRIPTION
Currently, each of the reporters bundled with nodeunit keeps the test results to itself; there's no way to get them out. That means that if you want to add any functionality to a reporter (such as a growl notification), you have to make your own fork of the reporter (which is especially cumbersome since most rely on nodeunit's internal `utils`).

With this pull request, each reporter accepts a `done` callback to its `options` hash that runs at the end of the reporter's own `done` method. That way, instead of implementing [an entire reporter](https://gist.github.com/1114731) to add growl notifications, you can just use the default reporter with a small extra callback:

```
reporters.default.run(['test'], {done: function(assertions) {
    var msg = 'FAILURES: ' + assertions.failures() + '/' + assertions.length + ' assertions failed (' + assertions.duration + 'ms)';
    exec("growlnotify -m '" + msg + "'");
}});
```
