### PR TITLE
Remove references to mutable require.paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,12 +294,10 @@ Adding nodeunit to Your Projects
 
 If you don't want people to have to install the nodeunit command-line tool,
 you'll want to create a script that runs the tests for your project with the
-correct require paths set up. Here's an example test script, with a deps
-directory containing the projects dependencies:
+correct require paths set up. Here's an example test script, that assumes you
+have nodeunit in a suitably located node_modules directory.
 
     #!/usr/bin/env node
-    require.paths.unshift(__dirname + '/deps');
-
     var reporter = require('nodeunit').reporters.default;
     reporter.run(['test']);
 
@@ -308,10 +306,10 @@ submodule. Using submodules makes it easy for developers to download nodeunit
 and run your test suite, without cluttering up your repository with
 the source code. To add nodeunit as a git submodule do the following:
 
-    git submodule add git://github.com/caolan/nodeunit.git deps/nodeunit
+    git submodule add git://github.com/caolan/nodeunit.git node_modules/nodeunit
 
-This will add nodeunit to the deps folder of your project. Now, when cloning
-the repository, nodeunit can be downloaded by doing the following:
+This will add nodeunit to the node_modules folder of your project. Now, when
+cloning the repository, nodeunit can be downloaded by doing the following:
 
     git submodule init
     git submodule update
@@ -320,9 +318,6 @@ Let's update the test script above with a helpful hint on how to get nodeunit,
 if its missing:
 
     #!/usr/bin/env node
-
-    require.paths.unshift(__dirname + '/deps');
-
     try {
         var reporter = require('nodeunit').reporters.default;
     }
@@ -416,7 +411,7 @@ module to ensure that test functions are actually run, and a basic level of
 nodeunit functionality is available.
 
 To run the nodeunit tests do:
-    
+
     make test
 
 __Note:__ There was a bug in node v0.2.0 causing the tests to hang, upgrading
@@ -429,4 +424,3 @@ Contributing
 Contributions to the project are most welcome, so feel free to fork and improve.
 When submitting a pull request, please run 'make lint' first to ensure
 we're following a consistent coding style.
-

--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -10,7 +10,7 @@ var
 // Until then, use console.log from npm (https://gist.github.com/1077544)
 require('../deps/console.log');
 
-require.paths.push(process.cwd());
+//require.paths.push(process.cwd());
 var args = process.ARGV.slice(2);
 
 var files = [];
@@ -102,7 +102,7 @@ if (files.length === 0) {
 if (config_file) {
     content = fs.readFileSync(config_file, 'utf8');
     var custom_options = JSON.parse(content);
-    
+
     for (var option in custom_options) {
         if (typeof option === 'string') {
             options[option] = custom_options[option];

--- a/test/test-runfiles.js
+++ b/test/test-runfiles.js
@@ -7,12 +7,11 @@ var assert = require('assert'),
 var setup = function (fn) {
     return function (test) {
         process.chdir(__dirname);
-        require.paths.push(__dirname);
         var env = {
-            mock_module1: require('./fixtures/mock_module1'),
-            mock_module2: require('./fixtures/mock_module2'),
-            mock_module3: require('./fixtures/dir/mock_module3'),
-            mock_module4: require('./fixtures/dir/mock_module4')
+            mock_module1: require(__dirname + '/fixtures/mock_module1'),
+            mock_module2: require(__dirname + '/fixtures/mock_module2'),
+            mock_module3: require(__dirname + '/fixtures/dir/mock_module3'),
+            mock_module4: require(__dirname + '/fixtures/dir/mock_module4')
         };
         fn.call(env, test);
     };
@@ -74,7 +73,9 @@ exports.testRunFiles = setup(function (test) {
     };
 
     nodeunit.runFiles(
-        ['fixtures/mock_module1.js', 'fixtures/mock_module2.js', 'fixtures/dir'],
+        [__dirname + '/fixtures/mock_module1.js',
+         __dirname + '/fixtures/mock_module2.js',
+         __dirname + '/fixtures/dir'],
         opts
     );
 });
@@ -147,9 +148,9 @@ try {
 if (CoffeeScript) {
     exports.testCoffeeScript = function (test) {
         process.chdir(__dirname);
-        require.paths.push(__dirname);
         var env = {
-            mock_coffee_module: require('./fixtures/coffee/mock_coffee_module')
+            mock_coffee_module: require(__dirname +
+                                        '/fixtures/coffee/mock_coffee_module')
         };
 
         test.expect(9);
@@ -206,7 +207,7 @@ if (CoffeeScript) {
         };
 
         nodeunit.runFiles(
-            ['fixtures/coffee/mock_coffee_module.coffee'],
+            [__dirname + 'fixtures/coffee/mock_coffee_module.coffee'],
             opts
         );
     };


### PR DESCRIPTION
Due to changes in node 0.5.4

I'm unsure how this will affect users of nodeunit who rely on this functionality.
