### PR TITLE
Added share directory to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ build: stamp-build
 stamp-build: $(wildcard  deps/* lib/*.js)
 	touch $@;
 	mkdir -p $(BUILDDIR)/nodeunit
-	cp -R bin deps index.js lib package.json $(BUILDDIR)/nodeunit
+	cp -R bin deps index.js lib package.json share $(BUILDDIR)/nodeunit
 	printf '#!/bin/sh\n$(NODEJS) $(NODEJSLIBDIR)/$(PACKAGE)/bin/nodeunit $$@' > $(BUILDDIR)/nodeunit.sh
 
 test:


### PR DESCRIPTION
This affects so, that you can't for instance run junit-formatted reports because of:

```
nnarhinen$ nodeunit --reporter junit --output foo.xml test.js 

/usr/local/lib/node/nodeunit/lib/reporters/junit.js:145
                    if (err) throw err;
                             ^
Error: ENOENT, No such file or directory '/usr/local/lib/node/nodeunit/lib/reporters/../../share/junit.xml.ejs'
```

This PR should fix this
