### PR TITLE
Node >=0.5: process.ARGV is now process.argv

### DIFF
--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -11,7 +11,7 @@ var
 require('../deps/console.log');
 
 //require.paths.push(process.cwd());
-var args = process.ARGV.slice(2);
+var args = (process.ARGV || process.argv).slice(2);
 
 var files = [];
 


### PR DESCRIPTION
Currently, running bin/nodeunit will kick out:

```
TypeError: Cannot call method 'slice' of undefined
```

... because process.ARGV is now process.argv: https://github.com/joyent/node/wiki/API-changes-between-v0.4-and-v0.6

Pull requests works with both ARGV and argv to work with both pre and post 0.5.
