### PR TITLE
small fix to bin file

### DIFF
--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -11,7 +11,7 @@ var
 require('../deps/console.log');
 
 //require.paths.push(process.cwd());
-var args = process.ARGV.slice(2);
+var args = process.argv.slice(2);
 
 var files = [];
 


### PR DESCRIPTION
uses `process.argv` instead of `process.ARGV`
