### PR TITLE
Fix for node 0.4.x/nodeunit >0.5.5 crash of junit report on large test trees

### DIFF
--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -144,8 +144,7 @@ exports.run = function (files, opts, callback) {
                 fs.readFile(tmpl, function (err, data) {
                     if (err) throw err;
                     var tmpl = data.toString();
-
-                    async.forEach(Object.keys(modules), function (k, cb) {
+                    for(var k in modules) {
                         var module = modules[k];
                         var rendered = ejs.render(tmpl, {
                             locals: {suites: [module]}
@@ -155,26 +154,23 @@ exports.run = function (files, opts, callback) {
                             module.name + '.xml'
                         );
                         console.log('Writing ' + filename);
-                        fs.writeFile(filename, rendered, cb);
-                    },
-                    function (err) {
-                        if (err) throw err;
-                        else if (assertions.failures()) {
-                            console.log(
-                                '\n' + bold(error('FAILURES: ')) +
-                                assertions.failures() + '/' +
-                                assertions.length + ' assertions failed (' +
-                                assertions.duration + 'ms)'
-                            );
-                        }
-                        else {
-                            console.log(
-                                '\n' + bold(ok('OK: ')) + assertions.length +
-                                ' assertions (' + assertions.duration + 'ms)'
-                            );
-                        }
-                    });
-
+                        fs.writeFileSync(filename, rendered, 'utf8');
+                    }
+                    if (assertions.failures()) {
+                        console.log(
+                            '\n' + bold(error('FAILURES: ')) +
+                            assertions.failures() + '/' +
+                            assertions.length + ' assertions failed (' +
+                            assertions.duration + 'ms)'
+                    	);
+                    }
+                    else {
+                        console.log(
+                            '\n' + bold(ok('OK: ')) + assertions.length +
+                            ' assertions (' + assertions.duration + 'ms)'
+                        );
+                    }
+                    
                     if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
                 });
             });


### PR DESCRIPTION
I have a project with 2 top level tests with chained sub tests. I notice that when using the junit reporter, nodeunit crashes during io write to disk with exit code 1.

I've tryed to debug the issue but even doing console.log of the renderer junit report or even the module object causes a crash.

I notice that if i write in a synchronous way then the problem does not exist. I've re-wrote the junit write to be synchronous and fixes the bug.

Please review this fix and consider it for inclusion,
Thanks!
