### PR TITLE
Added support for running single specific tests using their fully qualified name

### DIFF
--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -22,6 +22,7 @@ var testrunner,
     reporter_file = 'default',
     reporter_param_found = false,
     testspec_param_found = false;
+    testFullSpec_param_found = false;
 
 var usage = "Usage: nodeunit [options] testmodule1.js testfolder [...] \n" +
             "Options:\n\n" +
@@ -29,8 +30,10 @@ var usage = "Usage: nodeunit [options] testmodule1.js testfolder [...] \n" +
             "  --reporter FILE   optional path to a reporter file to customize the output\n" +
             "  --list-reporters  list available build-in reporters\n" +
             "  -t name,          specify a test to run\n" +
+            "  -f fullname,      specify a specific test to run. fullname is built so: \"outerGroup - .. - innerGroup - testName\"\n"  + 
             "  -h, --help        display this help and exit\n" +
             "  -v, --version     output version information and exit";
+            
 
 
 // load default options
@@ -65,6 +68,11 @@ args.forEach(function (arg) {
     } else if (testspec_param_found) {
         options.testspec = arg;
         testspec_param_found = false;
+    } else if (arg === '-f') {
+        testFullSpec_param_found = true;
+    } else if (testFullSpec_param_found) {
+        options.testFullSpec= arg;
+        testFullSpec_param_found = false;
     } else if (arg === '--list-reporters') {
         var reporters = fs.readdirSync(__dirname + '/../lib/reporters');
         reporters = reporters.filter(function (reporter_file) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -102,13 +102,15 @@ exports.runSuite = function (name, suite, opt, callback) {
         };
 
         if (typeof prop === 'function') {
-            var in_name = false;
+            var in_name = false,
+                in_specific_test = (_name.toString() === opt.testFullSpec) ? true : false;
             for (var i = 0; i < _name.length; i += 1) {
                 if (_name[i] === opt.testspec) {
                     in_name = true;
                 }
             }
-            if (!opt.testspec || in_name) {
+
+            if ((!opt.testFullSpec || in_specific_test) && (!opt.testspec || in_name)) {
                 if (opt.moduleStart) {
                     opt.moduleStart();
                 }

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -70,7 +70,8 @@ exports.run = function (files, options, callback) {
     });
 
 	var opts = {
-        testspec: options.testspec,
+	    testspec: options.testspec,
+	    testFullSpec: options.testFullSpec,
         moduleStart: function (name) {
             console.log('\n' + bold(name));
         },

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -55,6 +55,7 @@ exports.run = function (files, options, callback) {
     console.log('<body>');
     nodeunit.runFiles(paths, {
         testspec: options.testspec,
+        testFullSpec: options.testFullSpec,
         moduleStart: function (name) {
             console.log('<h2>' + name + '</h2>');
             console.log('<ol>');

--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -102,6 +102,7 @@ exports.run = function (files, opts, callback) {
 
     nodeunit.runFiles(paths, {
         testspec: opts.testspec,
+        testFullSpec: options.testFullSpec,
         moduleStart: function (name) {
             curModule = {
                 errorCount: 0,

--- a/lib/reporters/machineout.js
+++ b/lib/reporters/machineout.js
@@ -85,6 +85,7 @@ exports.run = function (files, options, callback) {
 
     nodeunit.runFiles(paths, {
         testspec: options.testspec,
+        testFullSpec: options.testFullSpec,
         moduleStart: function (name) {},
         testDone: function (name, assertions) {
             tracker.remove(name);

--- a/lib/reporters/minimal.js
+++ b/lib/reporters/minimal.js
@@ -53,7 +53,8 @@ exports.run = function (files, options, callback) {
     var start = new Date().getTime();
 
 	var opts = {
-        testspec: options.testspec,
+	    testspec: options.testspec,
+	    testFullSpec: options.testFullSpec,
         moduleStart: function (name) {
             process.stdout.write(bold(name) + ': ');
         },

--- a/lib/reporters/nested.js
+++ b/lib/reporters/nested.js
@@ -166,6 +166,7 @@ exports.run = function (files, options) {
 
     nodeunit.runFiles(paths, {
         testspec: options.testspec,
+        testFullSpec: options.testFullSpec,
         moduleStart: function (name) {
             console.log('\n' + bold(name));
         },

--- a/lib/reporters/skip_passed.js
+++ b/lib/reporters/skip_passed.js
@@ -57,6 +57,7 @@ exports.run = function (files, options, callback) {
 
     nodeunit.runFiles(paths, {
         testspec: options.testspec,
+        testFullSpec: options.testFullSpec,
         moduleStart: function (name) {
             console.log('\n' + bold(name));
         },

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -74,6 +74,7 @@ exports.run = function (files, options) {
 
     nodeunit.runFiles(paths, {
         testspec: options.testspec,
+        testFullSpec: options.testFullSpec,
         moduleStart: function (name) {
             console.log('\n' + bold(name));
         },


### PR DESCRIPTION
minor update, nodeunit now allows one to run a specific test within a module
Unlike testspec, which allows us to run a batch of tests containing the testspec given within it's nested path,
testFullSpec allows us to run a specific test within a module.
The fully qualified name of a test is built as so : 'outerGroup - .. - innerGroup - testName', e.g, 
{
    testgroup:{
        testgroup2:{
            test1: function (test)...
        }
    }
}
