### PR TITLE
update to utils.betterErrors to better handle undefined expected and actual

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -180,16 +180,10 @@ exports.httputil = function (cgi, envReady) {
  */
 
 exports.betterErrors = function (assertion) {
-    if (!assertion.error) return;
+    if (!assertion.error) return assertion;
 
     var e = assertion.error;
-    // deepEqual error message is a bit sucky, lets improve it!
-    // e.actual and e.expected could be null or undefined, so
-    // using getOwnPropertyDescriptor to see if they exist:
-    if (Object.getOwnPropertyDescriptor(e, 'actual') &&
-        Object.getOwnPropertyDescriptor(e, 'expected')) {
-
-        // alexgorbatchev 2010-10-22 :: Added a bit of depth to inspection
+    if (e.actual && e.expected) {
         var actual = util.inspect(e.actual, false, 10).replace(/\n$/, '');
         var expected = util.inspect(e.expected, false, 10).replace(/\n$/, '');
         var multiline = (

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   , "url" : "http://github.com/caolan/nodeunit.git"
   }
 , "devDependencies":
-  { "uglify-js": ">=1.1.0" }
+  { "uglify-js": ">=1.1.0"
+  , "should" : ">=0.4.2"
+  }
 , "bugs" : { "url" : "http://github.com/caolan/nodeunit/issues" }
 , "licenses" :
   [ { "type" : "MIT"

--- a/test/test-bettererrors.js
+++ b/test/test-bettererrors.js
@@ -1,0 +1,71 @@
+/*
+ *   Test utils.betterErrors. utils.betterErrors should provide sensible error messages even when the error does not
+ *   contain expected, actual or operator.
+ */
+var assert = require("../lib/assert");
+var should = require("should");
+var types = require("../lib/types");
+var util = require('util');
+var utils = require("../lib/utils");
+
+function betterErrorStringFromError(error) {
+    var assertion = types.assertion({error: error});
+    var better = utils.betterErrors(assertion);
+    return better.error.stack.toString();
+}
+
+function performBasicChecks(betterErrorString) {
+    betterErrorString.should.include("AssertionError");
+    betterErrorString.should.include("test-bettererrors");
+    betterErrorString.should.not.include("undefined");
+}
+
+/**
+ * Control test. Provide an AssertionError that contains actual, expected operator values.
+ * @param test the test object from nodeunit
+ */
+exports.testEqual = function (test) {
+    try {
+        assert.equal(true, false);
+    } catch (error) {
+        var betterErrorString = betterErrorStringFromError(error);
+        performBasicChecks(betterErrorString);
+        betterErrorString.should.include("true");
+        betterErrorString.should.include("false");
+        betterErrorString.should.include("==");
+        test.done();
+    }
+};
+
+/**
+ * Test an AssertionError that does not contain actual, expected or operator values.
+ * @param test the test object from nodeunit
+ */
+exports.testAssertThrows = function (test) {
+    try {
+        assert.throws(function () {
+        });
+    } catch (error) {
+        var betterErrorString = betterErrorStringFromError(error);
+        performBasicChecks(betterErrorString);
+        test.done();
+    }
+};
+
+/**
+ * Test with an error that is not an AssertionError.
+ * @param test the test object from nodeunit
+ */
+exports.testNonAssertionError = function (test) {
+    try {
+        throw new Error("test error");
+    } catch (error) {
+        var betterErrorString = betterErrorStringFromError(error);
+        betterErrorString.should.not.include("AssertionError");
+        betterErrorString.should.include("Error");
+        betterErrorString.should.include("test error");
+        betterErrorString.should.include("test-bettererrors");
+        betterErrorString.should.not.include("undefined");
+        test.done();
+    }
+};


### PR DESCRIPTION
Hi,

This is a minor update to utils.betterErrors that is not intended to incorporate any changes that could break anyone (e.g. no API changes, no change in return type).

The goal is to make utils.betterErrors play better with assertion errors that do not contain values for expected and actual. Prior to this change when there are no expected/actual values the message that is produced as the first line of the error stack is "AssertionError: undefined undefined undefined" - this happens for example with the assert.throws() assertion.

(I have to admit that I am unclear on the reason for the usage Object.getOwnPropertyDescriptor as it is this that is causing the problem. It would be possible to make the fix and still keep the usage of Object.getOwnPropertyDescriptor but since all the tests still pass hopefully I have not broken anything by removing it and replacing with a simple basic alternative - I look forward to being educated otherwise if this is not the case!)

As it happens this change also helps with richer assertion libraries such as should.js, which have many assertions that do not include expected or actual and is really my main objective - i.e. to improve nodeunit integration with alternative assertion libraries. To illustrate this I have included should.js as a devdependency in package.json and use it in the provided test case. If that dependency proves to be an obstacle then I am happy to remove it and re-submit.

thanks,
Allan
