### PR TITLE
Add deepEqual support for Buffer comparisons

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -159,6 +159,8 @@ assert.deepEqual = function deepEqual(actual, expected, message) {
   }
 };
 
+var Buffer = require && require('buffer') && require('buffer').Buffer;
+
 function _deepEqual(actual, expected) {
   // 7.1. All identical values are equivalent, as determined by ===.
   if (actual === expected) {
@@ -176,6 +178,17 @@ function _deepEqual(actual, expected) {
            actual.ignoreCase === expected.ignoreCase &&
            actual.multiline === expected.multiline;
 
+  } else if (Buffer && actual instanceof Buffer && expected instanceof Buffer) {
+    return (function() {
+      var i, len;
+
+      for (i = 0, len = expected.length; i < len; i++) {
+        if (actual[i] !== expected[i]) {
+          return false;
+        }
+      }
+      return actual.length === expected.length;
+    })();
   // 7.3. Other pairs that do not both pass typeof value == "object",
   // equivalence is determined by ==.
   } else if (typeof actual != 'object' && typeof expected != 'object') {


### PR DESCRIPTION
I don't know if this is something you are willing to add, but it would be pretty nice. I tried to add support in a way would still be compatible with in-browser testing too.

Thoughts?
