### PR TITLE
Added asserts from Christian Johansen's Test-Driven Javascript Development book

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -422,6 +422,12 @@ assert.isArray = function (value, message) {
     }
 };
 
+assert.isBuffer = function (value, message) {
+    if (!Buffer.isBuffer(value)) {
+        assert.fail(value, "Buffer", message, "isBuffer", assert.isBuffer);
+    }
+};
+
 assert.isNaN = function (value, message) {
     if (!isNaN(value)) {
         assert.fail(value, "NaN", message, "==", assert.isNaN);


### PR DESCRIPTION
Chapter 14 covers unit testing in node using a forked version of nodeunit from a few years ago.  Since I want to use the latest version of nodeunit in my tests, but find the additional asserts from Christian's book helpful, I thought it would be useful if I made an attempt at including them.

Now, Christian has a side project named node-assert-extras, but I couldn't easily see how to get that to play well with the nodeunit assert.js.  Instead, I just included a bunch of his assert additions into nodeunit assert.js.

I'm almost done reading chapter 14 and have only found one difference: he maps test.noException and variation to test.doesNotThrow.  I saw no need to add these additional mappings.

In short, this pull request does 99% of the work one needs to do in order to allow people using Christian's book to simply use the latest version of nodeunit.  Not to mention, it adds some very nice additional asserts.  I was hoping that someone would have already done the work to port those changes in, and indeed perhaps someone has but the pull request was rejected for some reason.  I am willing to do the legwork to get this into the mainline, so please let me know if you want me to do something.
