### PR TITLE
Update tap reporter

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -4,8 +4,8 @@
 
 var nodeunit = require('../nodeunit'),
     path = require('path'),
-    assert = require('tap-assert'),
-    TapProducer = require('tap-producer');
+    assert = require('tap').assert,
+    TapProducer = require('tap').Producer;
 
 /**
  * Reporter info string

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
 , "directories" : { "lib": "./lib", "doc" : "./doc", "man" : "./man1" }
 , "bin" : { "nodeunit" : "./bin/nodeunit" }
 , "dependencies" :
-  { "tap-assert": ">=0.0.9"
-  , "tap-producer": ">=0.0.1"
+  { "tap": ">=0.2.3"
   }
 }


### PR DESCRIPTION
The node-tap lib was updated with a new structure. Since previous versions produced tap that could be mis-read by other consumers, need to update the version and therefore how it's used.
