### PR TITLE
Machinecode reporter: Filter stack line with errors in types.js

### DIFF
--- a/lib/reporters/machineout.js
+++ b/lib/reporters/machineout.js
@@ -60,7 +60,7 @@ exports.run = function (files, options, callback) {
         }
         traceback = stack.split(/\n/).filter(function (line) {
             // exclude line of "types.js"
-            return ! RegExp(/types.js:83:39/).test(line);
+            return ! RegExp(/nodeunit\/lib\/types.js:/).test(line);
         });
         firstline = traceback.shift();
         trace = parseTrace(traceback[0]);


### PR DESCRIPTION
- Without this filter the filename is wrong
- This makes problems with the vim plugins: nodeunit.vim and vim-markgreen
  On unit test errors vim jumps to the types.js file

Same solution as in https://github.com/kusnier/nodeunit/blob/master/lib/reporters/tap.js#L52
