### PR TITLE
Exit process when tests are complete

### DIFF
--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -130,4 +130,5 @@ testrunner.run(files, options, function(err) {
     if (err) {
         process.exit(1);
     }
+    process.exit(0);
 });


### PR DESCRIPTION
This helps when some test code has a hanging processes.  

There are no more test cases to be covered, so exit.

Best,
Barret
