### PR TITLE
TAP reporter does not exit with any error code besides 0

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -20,7 +20,7 @@ exports.info = "TAP output";
  * @api public
  */
 
-exports.run = function (files, options) {
+exports.run = function (files, options, callback) {
 
     if (!options) {
         // load default options
@@ -60,6 +60,7 @@ exports.run = function (files, options) {
         },
         done: function (assertions) {
             output.end();
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         }
     });
 };


### PR DESCRIPTION
Without this, I can't actually use TAP reporter and drive from Makefiles et al (we have programmatic consumption of TAP output).