### PR TITLE
Fix a bug which cause scripts on command line run out of order

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ catch (e) {
  */
 
 exports.modulePaths = function (paths, callback) {
-    async.concat(paths, function (p, cb) {
+    async.concatSeries(paths, function (p, cb) {
         fs.stat(p, function (err, stats) {
             if (err) {
                 return cb(err);


### PR DESCRIPTION
There is a code processes path in parallel mode which MAY cause run scripts out of order.

e.g.
  nodeunit a.js b.js c.js d.js
  the execute order may looks like
    -> b.js
    -> c.js
    -> a.js
    -> d.js

I believe it's not an intended design, as all other codes are carefully handle path in series mode.
