### PR TITLE
Stop test after first assertion failure, and handle exceptions thrown from callbacks

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -65,6 +65,12 @@ exports.runTest = function (name, fn, opt, callback) {
     var start = new Date().getTime();
     var test = types.test(name, start, options, callback);
 
+    // Fail the test gracefully if an exception was thrown from a callback
+    process.removeAllListeners('uncaughtException');
+    process.on('uncaughtException', function (exception) {
+      test.done(exception);
+    });
+
     try {
         fn(test);
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -79,12 +79,7 @@ var assertWrapper = function (callback) {
         return function () {
             var message = arguments[arity - 1];
             var a = exports.assertion({method: new_method, message: message});
-            try {
-                assert[assert_method].apply(null, arguments);
-            }
-            catch (e) {
-                a.error = e;
-            }
+            assert[assert_method].apply(null, arguments);
             callback(a);
         };
     };


### PR DESCRIPTION
This pull request contains two suggested fixes:
1. Currently when an exception is thrown from an asynchronous callback the process crashes and subsequent tests don't run. Instead we should catch the exception and fail the test gracefully with test.done(exception).
2. Currently when any assertion fails the test continues and all other assertions are called. This is not a common behavior. The test should fail and stop after the first assertion failed, and move on to the next test.
