### PR TITLE
Add support for testing iced-coffee-script files.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,13 +20,15 @@ var async = require('../deps/async'),
  * extension in modulePaths if it is.
  */
 
-var extensionPattern;
+var extensionPattern = /\.js$/;
 try {
+  require('iced-coffee-script');
+  extensionPattern = /\.(?:js|coffee)$/;
+} catch (e) {
+  try {
     require('coffee-script');
     extensionPattern = /\.(?:js|coffee)$/;
-}
-catch (e) {
-    extensionPattern = /\.js$/;
+  } catch(e) {}
 }
 
 


### PR DESCRIPTION
I've been using iced-coffee-script and it's pretty cool.

This is a simple change to use it (if available) before loading coffee-script.
