### PR TITLE
Don't call runSuite on just anything, only objects

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -120,7 +120,7 @@ exports.runSuite = function (name, suite, opt, callback) {
                 return cb();
             }
         }
-        else {
+        else if(typeof prop == 'object') {
             exports.runSuite(_name, suite[k], opt, cb);
         }
     }, callback);


### PR DESCRIPTION
Check that we're calling runSuite on an object when prop is not a function.

This caused a bug when running my tests on [node-libspotify](http://github.com/floby/node-libspotify). I Couldn't track exactly why this function was called with undefined in the first place, but this fixed it and seemed appropriate.

Thanks for this framework by the way :)
