### PR TITLE
improve test: testNonAssertionError

### DIFF
--- a/test/test-bettererrors.js
+++ b/test/test-bettererrors.js
@@ -61,7 +61,7 @@ exports.testNonAssertionError = function (test) {
         throw new Error("test error");
     } catch (error) {
         var betterErrorString = betterErrorStringFromError(error);
-        betterErrorString.should.not.include("AssertionError");
+        betterErrorString.should.not.match(/\bAssertionError/);
         betterErrorString.should.include("Error");
         betterErrorString.should.include("test error");
         betterErrorString.should.include("test-bettererrors");


### PR DESCRIPTION
`make test` failed in my environment because the error thrown in test `testNonAssertionError`, after being passed through `betterErrorStringFromError`, contained the test name, which itself contained the "AssertionError" substring for which an assertion was negative-testing. This can be corrected by changing the assertion from substring inclusion to regular expression match.
