### PR TITLE
Stack trace is not HTML escaped in browser

### DIFF
--- a/lib/reporters/browser.js
+++ b/lib/reporters/browser.js
@@ -54,6 +54,12 @@ exports.run = function (modules, options) {
         return el;
     };
 
+    function HTMLEscape(str) {
+	return str.replace(/&/g, '&amp;')
+	    .replace(/</g, '&lt;')
+	    .replace(/>/g, '&gt;');
+    };
+
     var header = getOrCreate('h1', 'nodeunit-header');
     var banner = getOrCreate('h2', 'nodeunit-banner');
     var userAgent = getOrCreate('h2', 'nodeunit-userAgent');
@@ -92,7 +98,7 @@ exports.run = function (modules, options) {
                 var a = assertions[i];
                 if (a.failed()) {
                     li.innerHTML = (a.message || a.method || 'no message') +
-                        '<pre>' + (a.error.stack || a.error) + '</pre>';
+                        '<pre>' + HTMLEscape(a.error.stack || a.error) + '</pre>';
                     li.className = 'fail';
                 }
                 else {


### PR DESCRIPTION
When a test fails, the stack trace is not HTML escaped when displayed in the browser, which means that if you are testing the equality of two strings that contain HTML elements, you will not be able to see the HTML elements.  This patch fixes this issue.
