### PR TITLE
nodeunit /an/absolute.path/to/my-test.js breaks

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -122,7 +122,7 @@ exports.run = function (files, options, callback) {
     };
 	if (files && files.length) {
 	    var paths = files.map(function (p) {
-	        return path.join(process.cwd(), p);
+	        return path.resolve(process.cwd(), p);
 	    });
 	    nodeunit.runFiles(paths, opts);
 	} else {


### PR DESCRIPTION
It improperly tries to append the process.pwd() to the front of an already absolute path which results in a path that doesn't exist.
