### PR TITLE
Prefer setImmediate to process.nextTick.

### DIFF
--- a/deps/async.js
+++ b/deps/async.js
@@ -79,13 +79,18 @@
     //// exported async module functions ////
 
     //// nextTick implementation with browser-compatible fallback ////
-    if (typeof process === 'undefined' || !(process.nextTick)) {
+    if (typeof setImmediate === 'function') {
+        async.nextTick = function (fn) {
+            setImmediate(fn);
+        };
+    }
+    else if (typeof process !== 'undefined' && process.nextTick) {
+        async.nextTick = process.nextTick;
+    }
+    else {
         async.nextTick = function (fn) {
             setTimeout(fn, 0);
         };
-    }
-    else {
-        async.nextTick = process.nextTick;
     }
 
     async.forEach = function (arr, iterator, callback) {


### PR DESCRIPTION
This avoids errors due to recursive process.nextTick calls. (Supersedes #194.)
