### PR TITLE
adds support for --nocolor option

### DIFF
--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -31,6 +31,7 @@ var usage = "Usage: nodeunit [options] testmodule1.js testfolder [...] \n" +
             "  --list-reporters  list available build-in reporters\n" +
             "  -t name,          specify a test to run\n" +
             "  -f fullname,      specify a specific test to run. fullname is built so: \"outerGroup - .. - innerGroup - testName\"\n"  + 
+            "  -nc, --nocolor    suppress colorized output\n" +
             "  -h, --help        display this help and exit\n" +
             "  -v, --version     output version information and exit";
             
@@ -70,6 +71,8 @@ args.forEach(function (arg) {
         testspec_param_found = false;
     } else if (arg === '-f') {
         testFullSpec_param_found = true;
+    } else if (arg === '-nc' || arg === '--nocolor') {
+        options.suppressReporterColor = true;
     } else if (testFullSpec_param_found) {
         options.testFullSpec= arg;
         testFullSpec_param_found = false;

--- a/bin/nodeunit.json
+++ b/bin/nodeunit.json
@@ -6,5 +6,6 @@
     "bold_prefix": "\u001B[1m",
     "bold_suffix": "\u001B[22m",
     "assertion_prefix": "\u001B[35m",
-    "assertion_suffix": "\u001B[39m"
+    "assertion_suffix": "\u001B[39m",
+    "suppressReporterColor": false
 }

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -40,16 +40,16 @@ exports.run = function (files, options, callback) {
     }
 
     var error = function (str) {
-        return options.error_prefix + str + options.error_suffix;
+        return options.suppressReporterColor ? str : options.error_prefix + str + options.error_suffix;
     };
     var ok    = function (str) {
-        return options.ok_prefix + str + options.ok_suffix;
+        return options.suppressReporterColor ? str : options.ok_prefix + str + options.ok_suffix;
     };
     var bold  = function (str) {
-        return options.bold_prefix + str + options.bold_suffix;
+        return options.suppressReporterColor ? str : options.bold_prefix + str + options.bold_suffix;
     };
     var assertion_message = function (str) {
-        return options.assertion_prefix + str + options.assertion_suffix;
+        return options.suppressReporterColor ? str : options.assertion_prefix + str + options.assertion_suffix;
     };
 
     var start = new Date().getTime();


### PR DESCRIPTION
Nocolor can be added by adding either a '-nc' or '--nocolor' flag when invoking nodeunit.

```
$ nodeunit --nocolor my_file.js
```

Sets an option called 'suppressReporterColor', which can be included in your local nodeunit config.

``` javascript
{
    "suppressReporterColor": true
}
```
