### PR TITLE
This sets the module filename as the suite name

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -154,7 +154,7 @@ exports.runModule = function (name, mod, opt, callback) {
 
     var start = new Date().getTime();
 
-    exports.runSuite(null, mod, options, function (err, a_list) {
+    exports.runSuite(name, mod, options, function (err, a_list) {
         var end = new Date().getTime();
         var assertion_list = types.assertionList(a_list, end - start);
         options.moduleDone(name, assertion_list);

--- a/test/test-runmodule.js
+++ b/test/test-runmodule.js
@@ -34,18 +34,18 @@ exports.testRunModule = function (test) {
         testStart: function (name) {
             call_order.push('testStart');
             test.ok(
-                name.toString() === 'test1' ||
-                name.toString() === 'test2' ||
-                name.toString() === 'test3',
+                name.toString() === 'testmodule - test1' ||
+                name.toString() === 'testmodule - test2' ||
+                name.toString() === 'testmodule - test3',
                 'testStart called with test name '
             );
         },
         testDone: function (name, assertions) {
             call_order.push('testDone');
             test.ok(
-                name.toString() === 'test1' ||
-                name.toString() === 'test2' ||
-                name.toString() === 'test3',
+                name.toString() === 'testmodule - test1' ||
+                name.toString() === 'testmodule - test2' ||
+                name.toString() === 'testmodule - test3',
                 'testDone called with test name'
             );
         },
@@ -92,14 +92,14 @@ exports.testRunModuleTestSpec = function (test) {
         testStart: function (name) {
             call_order.push('testStart');
             test.equals(
-                name,'test2',
+                name,'testmodule - test2',
                 'testStart called with test name '
             );
         },
         testDone: function (name, assertions) {
             call_order.push('testDone');
             test.equal(
-                name, 'test2',
+                name, 'testmodule - test2',
                 'testDone called with test name'
             );
         },
@@ -166,11 +166,11 @@ exports.testNestedTests = function (test) {
         }
     }, function () {
         test.same(call_order, [
-            ['testStart', 'test1'], ['testDone', 'test1'],
-            ['testStart', 'suite', 't1'], ['testDone', 'suite', 't1'],
-            ['testStart', 'suite', 't2'], ['testDone', 'suite', 't2'],
-            ['testStart', 'suite', 'another_suite', 't3'],
-            ['testDone', 'suite', 'another_suite', 't3']
+            ['testStart', 'modulename', 'test1'], ['testDone', 'modulename', 'test1'],
+            ['testStart', 'modulename', 'suite', 't1'], ['testDone', 'modulename', 'suite', 't1'],
+            ['testStart', 'modulename', 'suite', 't2'], ['testDone', 'modulename', 'suite', 't2'],
+            ['testStart', 'modulename', 'suite', 'another_suite', 't3'],
+            ['testDone', 'modulename', 'suite', 'another_suite', 't3']
         ]);
         test.done();
     });


### PR DESCRIPTION
When running tests from the command line suites are your modules. It
seems that we should pass the file name through as the suite name

this makes the tap reporter actually usable