### PR TITLE
Fix failing testCoffeeScript

### DIFF
--- a/test/test-runfiles.js
+++ b/test/test-runfiles.js
@@ -207,7 +207,7 @@ if (CoffeeScript) {
         };
 
         nodeunit.runFiles(
-            [__dirname + 'fixtures/coffee/mock_coffee_module.coffee'],
+            [__dirname + '/fixtures/coffee/mock_coffee_module.coffee'],
             opts
         );
     };


### PR DESCRIPTION
 # testCoffeeScript
 /builddir/build/BUILD/package/lib/nodeunit.js:72
         if (err) throw err;
                           ^
 Error: ENOENT, stat '/builddir/build/BUILD/package/testfixtures/coffee/mock_coffee_module.coffee'

Missing slash between 'test' and 'fixtures' causing the test to fail on Fedora 18/19 (running Node 0.10.5).
