### PR TITLE
Fix a bug about nodeunit cannot open absolute path

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -122,7 +122,7 @@ exports.run = function (files, options, callback) {
     };
 	if (files && files.length) {
 	    var paths = files.map(function (p) {
-	        return path.join(process.cwd(), p);
+	        return path.resolve(process.cwd(), p);
 	    });
 	    nodeunit.runFiles(paths, opts);
 	} else {

--- a/lib/reporters/eclipse.js
+++ b/lib/reporters/eclipse.js
@@ -36,7 +36,7 @@ exports.run = function (files, options, callback) {
         if (p.indexOf('/') === 0) {
             return p;
         }
-        return path.join(process.cwd(), p);
+        return path.resolve(process.cwd(), p);
     });
     var tracker = track.createTracker(function (tracker) {
         if (tracker.unfinished()) {

--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -31,7 +31,7 @@ exports.run = function (files, options, callback) {
 
     var start = new Date().getTime();
     var paths = files.map(function (p) {
-        return path.join(process.cwd(), p);
+        return path.resolve(process.cwd(), p);
     });
 
     console.log('<html>');

--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -60,7 +60,7 @@ var ensureDir = function (path, callback) {
 var abspath = function (p, /*optional*/cwd) {
     if (p[0] === '/') return p;
     cwd = cwd || process.cwd();
-    return path.normalize(path.join(cwd, p));
+    return path.normalize(path.resolve(cwd, p));
 };
 
 
@@ -94,7 +94,7 @@ exports.run = function (files, opts, callback) {
 
     var start = new Date().getTime();
     var paths = files.map(function (p) {
-        return path.join(process.cwd(), p);
+        return path.resolve(process.cwd(), p);
     });
 
     var modules = {}
@@ -150,7 +150,7 @@ exports.run = function (files, opts, callback) {
                         var rendered = ejs.render(tmpl, {
                             locals: {suites: [module]}
                         });
-                        var filename = path.join(
+                        var filename = path.resolve(
                             opts.output,
                             module.name + '.xml'
                         );
@@ -171,7 +171,7 @@ exports.run = function (files, opts, callback) {
                             ' assertions (' + assertions.duration + 'ms)'
                         );
                     }
-                    
+
                     if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
                 });
             });

--- a/lib/reporters/machineout.js
+++ b/lib/reporters/machineout.js
@@ -67,15 +67,15 @@ exports.run = function (files, options, callback) {
         return [type, name, filename, row, column, message].join(":");
     };
     var paths = files.map(function (p) {
-        return path.join(process.cwd(), p);
+        return path.resolve(process.cwd(), p);
     });
     var tracker = track.createTracker(function (tracker) {
         if (tracker.unfinished()) {
             var names = tracker.names();
             for (var i = 0; i < names.length; i += 1) {
                 console.log(createErrorMessage(
-                    'Error', names[i], 
-                    '', '', '', 
+                    'Error', names[i],
+                    '', '', '',
                     'Undone tests - To fix this, make sure all tests call test.done()'
                 ));
             }

--- a/lib/reporters/minimal.js
+++ b/lib/reporters/minimal.js
@@ -112,7 +112,7 @@ exports.run = function (files, options, callback) {
 
 	if (files && files.length) {
 	    var paths = files.map(function (p) {
-	        return path.join(process.cwd(), p);
+	        return path.resolve(process.cwd(), p);
 	    });
 	    nodeunit.runFiles(paths, opts);
 	} else {

--- a/lib/reporters/nested.js
+++ b/lib/reporters/nested.js
@@ -57,7 +57,7 @@ exports.run = function (files, options) {
 
     var start = new Date().getTime();
     var paths = files.map(function (p) {
-        return path.join(process.cwd(), p);
+        return path.resolve(process.cwd(), p);
     });
     var tracker = track.createTracker(function (tracker) {
         var i, names;

--- a/lib/reporters/skip_passed.js
+++ b/lib/reporters/skip_passed.js
@@ -52,7 +52,7 @@ exports.run = function (files, options, callback) {
 
     var start = new Date().getTime();
     var paths = files.map(function (p) {
-        return path.join(process.cwd(), p);
+        return path.resolve(process.cwd(), p);
     });
 
     nodeunit.runFiles(paths, {

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -31,7 +31,7 @@ exports.run = function (files, options) {
     }
 
     var paths = files.map(function (p) {
-        return path.join(process.cwd(), p);
+        return path.resolve(process.cwd(), p);
     });
     var output = new TapProducer();
     output.pipe(process.stdout);

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -54,7 +54,7 @@ exports.run = function (files, options) {
 
     var start = new Date().getTime();
     var paths = files.map(function (p) {
-        return path.join(process.cwd(), p);
+        return path.resolve(process.cwd(), p);
     });
     var tracker = track.createTracker(function (tracker) {
         if (tracker.unfinished()) {


### PR DESCRIPTION
Fix a bug that is happen when nodeunit try to test a file by the absolute path.

`path.join(process.cwd(), filename)` is a code in some reporters does not work when the `filename` is absolute. Instead use `path.resolve`, and it works with an absolute file name.
