### PR TITLE
Expanding on the sandbox docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ context when setting up the sandbox.
         // Passing console into the sandbox will give your code access to it
         console: console
     };
-    var example = sandbox('example.js', box_globals );
+    var example = sandbox('example.js', box_globals);
 
 
 Running the nodeunit Tests


### PR DESCRIPTION
Figuring out what was actually going on in the sandbox took a bit of time and some googling. It would have been helpful for it to note exactly what was meant by the optional context. I've updated it to include a quick start for people using it with modules and such. I'm not sure if this is the proper place/formatting for that doc but the sandbox being an extremely powerful tool should have a bit more documentation to help people get off the ground with it.
