### PR TITLE
Fix crash, and prefer require('vm').Script over process.binding('evals').Script

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,18 @@
 var async = require('../deps/async'),
     fs = require('fs'),
     util = require('util'),
-    Script = process.binding('evals').Script || process.binding('evals').NodeScript,
+    Script = (function () {
+        try {
+            return require('vm').Script;
+        } catch (e) {}
+        try {
+            return process.binding('evals').Script;
+        } catch (e) {}
+        try {
+            return process.binding('evals').NodeScript
+        } catch (e) {}
+        throw "Failed to require 'Script'";
+    })(),
     http = require('http');
 
 


### PR DESCRIPTION
As far as I know, this should have been done after Node version 0.3.1
(see changelog here http://nodejs.org/changelog.html).  Without this
patch, I cannot properly run unit tests for Apache Thrift.

Fixes #110
