### PR TITLE
Node v0.11 does not allow to acces Script through process.binding('evals...

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,9 +11,17 @@
 var async = require('../deps/async'),
     fs = require('fs'),
     util = require('util'),
-    Script = process.binding('evals').Script || process.binding('evals').NodeScript,
     http = require('http');
 
+// In Node 0.11 you do not have access to
+// process.binding('evals')
+var Script
+try {
+  Script = require('vm').Script;
+}
+catch (e) {
+  Script = process.binding('evals').Script || process.binding('evals').NodeScript;
+}
 
 /**
  * Detect if coffee-script, iced-coffeescript, or streamline are available and 


### PR DESCRIPTION
...')

This was blowing up all my grunt tasks.
