### PR TITLE
Fix: verbose reporter didn't use its callback to report errors

### DIFF
--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -12,7 +12,7 @@ var nodeunit = require('../nodeunit'),
     utils = require('../utils'),
     fs = require('fs'),
     track = require('../track'),
-    path = require('path');
+    path = require('path'),
     AssertionError = require('../assert').AssertionError;
 
 /**
@@ -29,7 +29,7 @@ exports.info = "Verbose tests reporter"
  * @api public
  */
 
-exports.run = function (files, options) {
+exports.run = function (files, options, callback) {
 
     if (!options) {
         // load default options
@@ -115,6 +115,8 @@ exports.run = function (files, options) {
                    ' assertions (' + assertions.duration + 'ms)'
                 );
             }
+
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         },
         testStart: function(name) {
             tracker.put(name);


### PR DESCRIPTION
Code was copied from default.js.
