### PR TITLE
Make it work with Node Unstable v0.11.7: get Script from vm module

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,7 @@
 var async = require('../deps/async'),
     fs = require('fs'),
     util = require('util'),
-    Script = process.binding('evals').Script || process.binding('evals').NodeScript,
+    Script = require('vm').Script,
     http = require('http');
 
 


### PR DESCRIPTION
This makes it work with v0.11.7.
