### PR TITLE
utils: do not use internal Node API

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,7 @@
 var async = require('../deps/async'),
     fs = require('fs'),
     util = require('util'),
-    Script = process.binding('evals').Script || process.binding('evals').NodeScript,
+    Script = require('vm').Script,
     http = require('http');
 
 


### PR DESCRIPTION
process.binding() is undocumented internal API, and not intended for use in userland modules.

In this case, it's also unnecessary, since vm.Script is exactly equal to the old binding('evals').NodeScript.  However, the process.bindin('evals') is gone as of Node 0.11.
