### PR TITLE
Ensure all Reporters accept a callback function

### DIFF
--- a/lib/reporters/browser.js
+++ b/lib/reporters/browser.js
@@ -30,7 +30,7 @@ exports.info = "Browser-based test reporter";
  * @api public
  */
 
-exports.run = function (modules, options) {
+exports.run = function (modules, options, callback) {
     var start = new Date().getTime(), div;
 	options = options || {};
 	div = options.div || document.body;
@@ -116,6 +116,8 @@ exports.run = function (modules, options) {
                 assertions.passes() + '</span> assertions of ' +
                 '<span class="all">' + assertions.length + '<span> passed, ' +
                 assertions.failures() + ' failed.';
+
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         }
     });
 };

--- a/lib/reporters/lcov.js
+++ b/lib/reporters/lcov.js
@@ -18,20 +18,22 @@ exports.info = 'The LCOV reporter reads JS files instrumented by JSCoverage (htt
  * @api public
  */
 
-exports.run = function (files) {
+exports.run = function (files, options, callback) {
 
     var paths = files.map(function (p) {
         return path.join(process.cwd(), p);
     });
-
+    
     nodeunit.runFiles(paths, {
-        done: function () {
+        done: function (assertions) {
             var cov = (global || window)._$jscoverage || {};
 
             Object.keys(cov).forEach(function (filename) {
                 var data = cov[filename];
                 reportFile(filename, data);
             });
+            
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         }
     });
 };

--- a/lib/reporters/nested.js
+++ b/lib/reporters/nested.js
@@ -29,7 +29,7 @@ exports.info = "Nested test reporter";
  * @api public
  */
 
-exports.run = function (files, options) {
+exports.run = function (files, options, callback) {
 
     if (!options) {
         // load default options
@@ -206,6 +206,8 @@ exports.run = function (files, options) {
                         ' assertions (' + assertions.duration + 'ms)'
                 );
             }
+            
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         },
         testStart: function (name) {
             tracker.put(name);

--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -20,7 +20,7 @@ exports.info = "TAP output";
  * @api public
  */
 
-exports.run = function (files, options) {
+exports.run = function (files, options, callback) {
 
     if (!options) {
         // load default options
@@ -60,6 +60,8 @@ exports.run = function (files, options) {
         },
         done: function (assertions) {
             output.end();
+            
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         }
     });
 };

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -29,7 +29,7 @@ exports.info = "Verbose tests reporter"
  * @api public
  */
 
-exports.run = function (files, options) {
+exports.run = function (files, options, callback) {
 
     if (!options) {
         // load default options
@@ -115,6 +115,8 @@ exports.run = function (files, options) {
                    ' assertions (' + assertions.duration + 'ms)'
                 );
             }
+            
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
         },
         testStart: function(name) {
             tracker.put(name);


### PR DESCRIPTION
This change ensures all reporters accept a callback function for a third parameter of their `run()` function, which is fired when the tests are done.

`browser`, `lcov`, `nested`, `tap` and `verbose` needed these parameters.

`default`, `junit`, etc already accepted a 3rd callback parameter.

The reason for this change is because of a separate change I'm also pull-requesting for `grunt-contrib-nodeunit`, which adds `reporter` and `reporterOutput` options to choose the reporter and an optional output file for the results.  Prior to this change, if the grunt config specified a reporter that didn't accept the 3rd callback parameter, grunt would hang waiting for a callback that never happens.
