### PR TITLE
explicitly require('fs') in tap reporter

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -5,7 +5,8 @@
 var nodeunit = require('../nodeunit'),
     path = require('path'),
     assert = require('tap').assert,
-    TapProducer = require('tap').Producer;
+    TapProducer = require('tap').Producer,
+    fs = require('fs');
 
 /**
  * Reporter info string


### PR DESCRIPTION
Fixes a bug caused when run in a project that does not already include fs, the following error message is produced:

```
ReferenceError: fs is not defined
    at Object.exports.run (/.../node_modules/nodeunit/lib/reporters/tap.js:27:23)
    at task.async [as action] (/.../Jakefile.js:20:12)
```
