### PR TITLE
Tap reporter updates

### DIFF
--- a/lib/reporters/tap.js
+++ b/lib/reporters/tap.js
@@ -5,7 +5,8 @@
 var nodeunit = require('../nodeunit'),
     path = require('path'),
     assert = require('tap').assert,
-    TapProducer = require('tap').Producer;
+    TapProducer = require('tap').Producer,
+    fs = require('fs');
 
 /**
  * Reporter info string


### PR DESCRIPTION
The TAP reporter bundled with nodeunit looks to be either incomplete or just plain out of date with the default reporter API.

I've explicitly required a dependency that was not explicit, and ported callback functionality from the default reporter.
