### PR TITLE
Added optional callback testReady(test).

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ callbacks:
   module have completed (see assertions object reference below)
   ALL tests within the module
 * __testStart(name)__ - called before a test function is run
+* __testReady(test)__ - called before a test function is run with the test object that will be passed to the test function
 * __testDone(name, assertions)__ - called once a test function has completed
   (by calling test.done())
 * __log(assertion)__ - called whenever an assertion is made (see assertion

--- a/lib/core.js
+++ b/lib/core.js
@@ -65,6 +65,7 @@ exports.runTest = function (name, fn, opt, callback) {
     var start = new Date().getTime();
     var test = types.test(name, start, options, callback);
 
+    options.testReady(test);
     try {
         fn(test);
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -180,6 +180,7 @@ exports.options = function (opt) {
     optionalCallback('moduleStart');
     optionalCallback('moduleDone');
     optionalCallback('testStart');
+    optionalCallback('testReady');
     optionalCallback('testDone');
     //optionalCallback('log');
 

--- a/test/test-runfiles.js
+++ b/test/test-runfiles.js
@@ -19,7 +19,7 @@ var setup = function (fn) {
 
 
 exports.testRunFiles = setup(function (test) {
-    test.expect(24);
+    test.expect(28);
     var runModule_copy = nodeunit.runModule;
 
     var runModule_calls = [];
@@ -31,6 +31,9 @@ exports.testRunFiles = setup(function (test) {
         },
         testDone: function () {
             return 'testDone';
+        },
+        testReady: function () {
+            return 'testReady';
         },
         testStart: function () {
             return 'testStart';
@@ -61,6 +64,7 @@ exports.testRunFiles = setup(function (test) {
 
     nodeunit.runModule = function (name, mod, options, callback) {
         test.equals(options.testDone, opts.testDone);
+        test.equals(options.testReady, opts.testReady);
         test.equals(options.testStart, opts.testStart);
         test.equals(options.log, opts.log);
         test.ok(typeof name === "string");
@@ -87,6 +91,9 @@ exports.testRunFilesEmpty = function (test) {
             test.ok(false, 'should not be called');
         },
         testDone: function () {
+            test.ok(false, 'should not be called');
+        },
+        testReady: function () {
             test.ok(false, 'should not be called');
         },
         testStart: function () {
@@ -122,6 +129,9 @@ exports.testEmptyDir = function (test) {
             testDone: function () {
                 test.ok(false, 'should not be called');
             },
+            testReady: function () {
+                test.ok(false, 'should not be called');
+            },
             testStart: function () {
                 test.ok(false, 'should not be called');
             },
@@ -153,7 +163,7 @@ if (CoffeeScript) {
                                         '/fixtures/coffee/mock_coffee_module')
         };
 
-        test.expect(9);
+        test.expect(10);
         var runModule_copy = nodeunit.runModule;
 
         var runModule_calls = [];
@@ -165,6 +175,9 @@ if (CoffeeScript) {
             },
             testDone: function () {
                 return 'testDone';
+            },
+            testReady: function () {
+                return 'testReady';
             },
             testStart: function () {
                 return 'testStart';
@@ -195,6 +208,7 @@ if (CoffeeScript) {
 
         nodeunit.runModule = function (name, mod, options, callback) {
             test.equals(options.testDone, opts.testDone);
+            test.equals(options.testReady, opts.testReady);
             test.equals(options.testStart, opts.testStart);
             test.equals(options.log, opts.log);
             test.ok(typeof name === "string");

--- a/test/test-runmodule.js
+++ b/test/test-runmodule.js
@@ -8,7 +8,7 @@ var nodeunit = require('../lib/nodeunit'); // @REMOVE_LINE_FOR_BROWSER
 
 
 exports.testRunModule = function (test) {
-    test.expect(11);
+    test.expect(59);
     var call_order = [];
     var testmodule = {
         test1: function (test) {
@@ -40,6 +40,25 @@ exports.testRunModule = function (test) {
                 'testStart called with test name '
             );
         },
+        testReady: function (tst) {
+            call_order.push('testReady');
+            test.ok(tst.done, 'testReady called with non-test object');
+            test.ok(tst.ok, 'testReady called with non-test object');
+            test.ok(tst.same, 'testReady called with non-test object');
+            test.ok(tst.expect, 'testReady called with non-test object');
+            test.ok(tst._assertion_list, 'testReady called with non-test object');
+            test.ok(tst.AssertionError, 'testReady called with non-test object');
+            test.ok(tst.fail, 'testReady called with non-test object');
+            test.ok(tst.equal, 'testReady called with non-test object');
+            test.ok(tst.notEqual, 'testReady called with non-test object');
+            test.ok(tst.deepEqual, 'testReady called with non-test object');
+            test.ok(tst.notDeepEqual, 'testReady called with non-test object');
+            test.ok(tst.strictEqual, 'testReady called with non-test object');
+            test.ok(tst.notStrictEqual, 'testReady called with non-test object');
+            test.ok(tst.throws, 'testReady called with non-test object');
+            test.ok(tst.doesNotThrow, 'testReady called with non-test object');
+            test.ok(tst.ifError, 'testReady called with non-test object');
+        },
         testDone: function (name, assertions) {
             call_order.push('testDone');
             test.ok(
@@ -56,9 +75,9 @@ exports.testRunModule = function (test) {
             test.equals(name, 'testmodule');
             test.ok(typeof assertions.duration === "number");
             test.same(call_order, [
-                'testStart', 'test1', 'log', 'testDone',
-                'testStart', 'test2', 'log', 'log', 'testDone',
-                'testStart', 'test3', 'testDone',
+                'testStart', 'testReady', 'test1', 'log', 'testDone',
+                'testStart', 'testReady', 'test2', 'log', 'log', 'testDone',
+                'testStart', 'testReady', 'test3', 'testDone',
                 'moduleDone'
             ]);
         }
@@ -67,7 +86,7 @@ exports.testRunModule = function (test) {
 
 
 exports.testRunModuleTestSpec = function (test) {
-    test.expect(6);
+    test.expect(22);
     var call_order = [];
     var testmodule = {
         test1: function (test) {
@@ -96,6 +115,25 @@ exports.testRunModuleTestSpec = function (test) {
                 'testStart called with test name '
             );
         },
+        testReady: function (tst) {
+            call_order.push('testReady');
+            test.ok(tst.done, 'testReady called with non-test object');
+            test.ok(tst.ok, 'testReady called with non-test object');
+            test.ok(tst.same, 'testReady called with non-test object');
+            test.ok(tst.expect, 'testReady called with non-test object');
+            test.ok(tst._assertion_list, 'testReady called with non-test object');
+            test.ok(tst.AssertionError, 'testReady called with non-test object');
+            test.ok(tst.fail, 'testReady called with non-test object');
+            test.ok(tst.equal, 'testReady called with non-test object');
+            test.ok(tst.notEqual, 'testReady called with non-test object');
+            test.ok(tst.deepEqual, 'testReady called with non-test object');
+            test.ok(tst.notDeepEqual, 'testReady called with non-test object');
+            test.ok(tst.strictEqual, 'testReady called with non-test object');
+            test.ok(tst.notStrictEqual, 'testReady called with non-test object');
+            test.ok(tst.throws, 'testReady called with non-test object');
+            test.ok(tst.doesNotThrow, 'testReady called with non-test object');
+            test.ok(tst.ifError, 'testReady called with non-test object');
+        },
         testDone: function (name, assertions) {
             call_order.push('testDone');
             test.equal(
@@ -109,7 +147,7 @@ exports.testRunModuleTestSpec = function (test) {
             test.equals(name, 'testmodule');
             test.ok(typeof assertions.duration === "number");
             test.same(call_order, [
-                'testStart', 'test2', 'log', 'log', 'testDone',
+                'testStart', 'testReady', 'test2', 'log', 'log', 'testDone',
                 'moduleDone'
             ]);
         }
@@ -123,6 +161,9 @@ exports.testRunModuleEmpty = function (test) {
         },
         testStart: function (name) {
             test.ok(false, 'testStart should not be called');
+        },
+        testReady: function (tst) {
+            test.ok(false, 'testReady should not be called');
         },
         testDone: function (name, assertions) {
             test.ok(false, 'testDone should not be called');
@@ -161,15 +202,19 @@ exports.testNestedTests = function (test) {
         testStart: function (name) {
             call_order.push(['testStart'].concat(name));
         },
+        testReady: function (tst) {
+            call_order.push(['testReady']);
+        },
         testDone: function (name, assertions) {
             call_order.push(['testDone'].concat(name));
         }
     }, function () {
         test.same(call_order, [
-            ['testStart', 'test1'], ['testDone', 'test1'],
-            ['testStart', 'suite', 't1'], ['testDone', 'suite', 't1'],
-            ['testStart', 'suite', 't2'], ['testDone', 'suite', 't2'],
+            ['testStart', 'test1'], ['testReady'], ['testDone', 'test1'],
+            ['testStart', 'suite', 't1'], ['testReady'], ['testDone', 'suite', 't1'],
+            ['testStart', 'suite', 't2'], ['testReady'], ['testDone', 'suite', 't2'],
             ['testStart', 'suite', 'another_suite', 't3'],
+            ['testReady'],
             ['testDone', 'suite', 'another_suite', 't3']
         ]);
         test.done();


### PR DESCRIPTION
The testReady(test) is called before a test function is run with
the same test object that will be handed to the test function.
This allows for decorating the test object with additional
functionality.

For instance, in the case of
http://github.com/dalnefre/tart-nodeunit it enables adding
test.sponsor(...) and test.dispatch(...) without changing nodeunit.
