### PR TITLE
#244 catch async exceptions and log their stacks

### DIFF
--- a/lib/track.js
+++ b/lib/track.js
@@ -27,6 +27,11 @@ exports.createTracker = function (on_exit) {
         }
     };
 
+    process.on('uncaughtException', function (err) {
+        console.error(err.stack);
+        process.exit(1);
+    });
+
     process.on('exit', function() {
         on_exit = on_exit || exports.default_on_exit;
         on_exit(tracker);


### PR DESCRIPTION
This fixes the the problem where asynchronously thrown exceptions within tests are not caught or logged. This problem is actually specific to node v0.10

Credit for the fix goes to @tjfontaine 
