### PR TITLE
Hide optional dependencies from browserify

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,17 +24,17 @@ var extensions = [ 'js' ];  // js is always supported: add it unconditionally
 var extensionPattern;
 
 try {
-    require('coffee-script');
+    require('coffee' + '-script');
     extensions.push('coffee');
 } catch (e) { }
 
 try {
-    require('iced-coffee-script');
+    require('iced-coffee' + '-script');
     extensions.push('iced');
 } catch (e) { }
 
 try {
-    require('streamline').register();
+    require('stream' + 'line').register();
     extensions.push('_coffee');
     extensions.push('_js');
 } catch (e) { }


### PR DESCRIPTION
A bit weird, but it works.
