### PR TITLE
A little trick to stop tap breaking browserify

### DIFF
--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -1,3 +1,15 @@
+// This is a hack to make browserify skip tap
+var tap;
+try {
+    tap = require('./' + 'tap');
+} catch (ex) {
+    tap = {
+        run: function() {
+            throw new Error('Sorry, tap reporter not available');
+        }
+    };
+}
+
 module.exports = {
     'junit': require('./junit'),
     'default': require('./default'),
@@ -6,7 +18,7 @@ module.exports = {
     'html': require('./html'),
     'eclipse': require('./eclipse'),
     'machineout': require('./machineout'),
-    'tap': require('./tap'),
+    'tap': tap,
     'nested': require('./nested'),
     'verbose' : require('./verbose'),
     'lcov' : require('./lcov')


### PR DESCRIPTION
This one is a bit more involved than the last one - and much hackier.

It doesn't make the other reporters work, but it does stop tap from breaking the bootstrap, allowing third party runners to use nodeunit under browserify.

before

```
> browserify index.js | testling

not ok 1 Error: Error: Cannot find module 'inherits' on line 6699
```

after

```
> browserify index.js | testling


```
