### PR TITLE
Make it work with coffee-script > 1.7.0

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,7 +29,7 @@ try {
 } catch (e) { }
 
 try {
-    require('iced-coffee' + '-script');
+    require('iced-coffee' + '-script/register');
     extensions.push('iced');
 } catch (e) { }
 


### PR DESCRIPTION
http://coffeescript.org/ -> Change Log -> 1.7.0

> When requiring CoffeeScript files in Node you must now explicitly register the compiler. This can be done with require `coffee-script/register` or `CoffeeScript.register()`. Also for configuration such as Mocha's, use `coffee-script/register`.

I checked with 1.6.3. Seems to be working well, but check it please yourself just in case.
Thx.
