### PR TITLE
Added assert.match to test text for regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Nodeunit uses the functions available in the node.js
 * __notStrictEqual(actual, expected, [message])__ - Tests strict non-equality,
   as determined by the strict not equal operator ( !== )
 * __throws(block, [error], [message])__ - Expects block to throw an error.
+* __match(regex, actual, [message])__ - Tests if `regex` matches `actual`.
 * __doesNotThrow(block, [error], [message])__ - Expects block not to throw an
   error.
 * __ifError(value)__ - Tests if value is not a false value, throws if it is a

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -346,6 +346,13 @@ assert.throws = function(block, /*optional*/error, /*optional*/message) {
   _throws.apply(this, [true].concat(pSlice.call(arguments)));
 };
 
+// 12. Tests if the regular expression actual matches the
+// text provided in expected
+
+assert.match = function match(actual, expected, message) {
+  if (!actual.test(expected)) fail(expected, actual, message, 'matches', assert.match);
+};
+
 // EXTENSION! This is annoying to write outside this module.
 assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
   _throws.apply(this, [false].concat(pSlice.call(arguments)));

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -150,6 +150,14 @@ exports.testThrowsWithErrorValidation = makeTest('throws',
         return false;
     }]
 );
+exports.testMatch = makeTest('match',
+  [/^basic$/, 'basic'],
+  [/^$/, 'basic']
+);
+exports.testMatch = makeTest('match',
+  [/^[0-9a-f]{40}$/, '3ccc98002d0edd06bff9de6cdc1725eb3ae1c638'],
+  [/^[0-9a-f]{1,40}$/, '3CCC98002D0EDD06BFF9DE6CDC1725EB3AE1C638']
+);
 exports.testDoesNotThrows = makeTest('doesNotThrow',
     [function () {
         return;


### PR DESCRIPTION
Sometimes it's useful to test if some returned text
matches a specific regex. It may be a dynamic time which
should be a certain structure, but the exact values are not
important to the outcome of the test. Regular Expression
are already widely used and common in JavaScript and can be
very powerful from a testing point of view aswell.