### PR TITLE
JSON.stringify(undefined) produces an empty string. Patch to clarify output

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -87,9 +87,9 @@ assert.AssertionError.prototype.toString = function() {
     return [this.name+":", this.message].join(' ');
   } else {
     return [ this.name+":"
-           , JSON.stringify(this.expected )
+           , typeof this.expected !== 'undefined' ? JSON.stringify(this.expected) : 'undefined'
            , this.operator
-           , JSON.stringify(this.actual)
+           , typeof this.actual !== 'undefined' ? JSON.stringify(this.actual) : 'undefined'
            ].join(" ");
   }
 };


### PR DESCRIPTION
I spent a good half hour trying to figure out what was wrong with my assertion before I figured out what the output meant.

Before patch:

```
AssertionError: [{"id":1,"name":"john doe"}] deepEqual
    at Object.deepEqual (/Users/chiper/ChiperSoft/JS/seaquell/node_modules/nodeunit/lib/types.js:83:39)
    at /Users/chiper/ChiperSoft/JS/seaquell/tests/seaquell.js:120:8
    ...
```

After patch:

```
AssertionError: [{"id":1,"name":"john doe"}] deepEqual undefined
    at Object.deepEqual (/Users/chiper/ChiperSoft/JS/seaquell/node_modules/nodeunit/lib/types.js:83:39)
    at /Users/chiper/ChiperSoft/JS/seaquell/tests/seaquell.js:120:8
    ...
```
