### PR TITLE
Add a context payload to the test object.

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -160,6 +160,8 @@ exports.test = function (name, start, options, callback) {
             test[k] = wrapAssert(k, k, assert[k].length);
         }
     }
+    // add environment context if any passed with options
+    options.context && (test['context'] = options.context);
     return test;
 };
 


### PR DESCRIPTION
To enable passing request context into the test case, so that we can do unit test against web request.
