### PR TITLE
Fix bug #247

### DIFF
--- a/test/test-runfiles.js
+++ b/test/test-runfiles.js
@@ -152,6 +152,9 @@ exports.testEmptyDir = function (test) {
 var CoffeeScript;
 try {
     CoffeeScript = require('coffee-script');
+    if (CoffeeScript.register != null) {
+        CoffeeScript.register();
+    }
 } catch (e) {
 }
 


### PR DESCRIPTION
Coffeescript 1.7 and later require calling `CoffeeScript.register()` to load `.coffee` files.  This patch should work for previous versions as well.
