### PR TITLE
Add missing docs for cmd line options '-t' and '-f'

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ is used.
 * __--config FILE__ - load config options from a JSON file, allows
 the customisation of color schemes for the default test reporter etc. See
 bin/nodeunit.json for current available options.
+* __-t testName__ - run specifc test only.
+* __-f fullTestName__ - run specific test only. fullTestName is built so: "outerGroup - .. - innerGroup - testName".
 * __--version__ or __-v__ - report nodeunit version
 * __--help__ - show nodeunit help
 

--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -29,11 +29,11 @@ var usage = "Usage: nodeunit [options] testmodule1.js testfolder [...] \n" +
             "  --config FILE     the path to a JSON file with options\n" +
             "  --reporter FILE   optional path to a reporter file to customize the output\n" +
             "  --list-reporters  list available build-in reporters\n" +
-            "  -t name,          specify a test to run\n" +
-            "  -f fullname,      specify a specific test to run. fullname is built so: \"outerGroup - .. - innerGroup - testName\"\n"  + 
+            "  -t testName,      specify a test to run\n" +
+            "  -f fullTestName,  specify a specific test to run. fullTestName is built so: \"outerGroup - .. - innerGroup - testName\"\n"  +
             "  -h, --help        display this help and exit\n" +
             "  -v, --version     output version information and exit";
-            
+
 
 
 // load default options

--- a/doc/nodeunit.md
+++ b/doc/nodeunit.md
@@ -29,7 +29,13 @@ Nodeunit is a simple unit testing tool based on the node.js assert module.
   __--list-reporters__:
       List available build-in reporters.
 
-  __-h__, __--help__:  
+  __-t testName__:
+      Run specifc test only.
+
+  __-f fullTestName__:
+      Run specific test only. fullTestName is built so: "outerGroup - .. - innerGroup - testName".
+
+  __-h__, __--help__:
       Display the help and exit.
 
   __-v__, __--version__:


### PR DESCRIPTION
The documentation for '-t' and '-f' was only present on the command line (--help) but not in the documentation (i.e. the Markdown files) itself.
