### PR TITLE
Always display better AssertionError msg

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -196,7 +196,7 @@ exports.betterErrors = function (assertion) {
         return assertion;
     }
     var e = assertion.error;
-    if (e.actual && e.expected) {
+    if (e.operator) {
         var actual = util.inspect(e.actual, false, 10).replace(/\n$/, '');
         var expected = util.inspect(e.expected, false, 10).replace(/\n$/, '');
         var multiline = (


### PR DESCRIPTION
Fix `betterErrors` to display the useful Assertion message even when
actual/expected are 0 or undefined. Fixes #220
