### PR TITLE
Make running test groups idempotent

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -278,32 +278,39 @@ var getSerialCallback = function (fns) {
 
 var wrapGroup = function (group, setUps, tearDowns) {
     var tests = {};
+    var clone = {};
+
+    for (var key in group) {
+        if (group.hasOwnProperty(key)) {
+            clone[key] = group[key];
+        }
+    }
 
     var setUps = setUps ? setUps.slice(): [];
     var tearDowns = tearDowns ? tearDowns.slice(): [];
 
-    if (group.setUp) {
-        setUps.push(group.setUp);
-        delete group.setUp;
+    if (clone.setUp) {
+        setUps.push(clone.setUp);
+        delete clone.setUp;
     }
-    if (group.tearDown) {
-        tearDowns.unshift(group.tearDown);
-        delete group.tearDown;
+    if (clone.tearDown) {
+        tearDowns.unshift(clone.tearDown);
+        delete clone.tearDown;
     }
 
-    var keys = _keys(group);
+    var keys = _keys(clone);
 
     for (var i = 0; i < keys.length; i += 1) {
         var k = keys[i];
-        if (typeof group[k] === 'function') {
+        if (typeof clone[k] === 'function') {
             tests[k] = wrapTest(
                 getSerialCallback(setUps),
                 getSerialCallback(tearDowns),
-                group[k]
+                clone[k]
             );
         }
-        else if (typeof group[k] === 'object') {
-            tests[k] = wrapGroup(group[k], setUps, tearDowns);
+        else if (typeof clone[k] === 'object') {
+            tests[k] = wrapGroup(clone[k], setUps, tearDowns);
         }
     }
     return tests;

--- a/test/fixtures/mock_module5.js
+++ b/test/fixtures/mock_module5.js
@@ -1,0 +1,16 @@
+exports.name = 'mock_module3';
+
+exports.setUp = function (next) {
+    this.foo = 'bar';
+    next();
+};
+
+exports.testFoo = function (test) {
+    test.equal(this.foo, 'bar');
+    test.done();
+};
+
+exports.tearDown = function (next) {
+    this.foo = 'baz';
+    next();
+};

--- a/test/test-runfiles.js
+++ b/test/test-runfiles.js
@@ -148,6 +148,20 @@ exports.testEmptyDir = function (test) {
     });
 };
 
+exports.testRunFilesWithDuplicate = function (test) {
+    test.expect(1);
+
+    nodeunit.runFiles([
+        __dirname + '/fixtures/mock_module5.js',
+        __dirname + '/fixtures/mock_module5.js'
+    ], {
+        done: function (assertions) {
+            test.equals(assertions.failures(), 0, 'failures');
+            test.done();
+        }
+    });
+};
+
 
 var CoffeeScript;
 try {


### PR DESCRIPTION
Currently the internal function `wrapGroup` deletes the `setUp` and `tearDown` method of any test group. When running from the command line, test groups will be provided by the Node module loader or module cache. This patch performs a shallow copy of the module object inside `wrapGroup` so that the original setup and teardown methods are preserved. This means that repeatedly running tests on the same module or file in the same execution context will always yield the same output.

Some background: I encountered a bug when running nodeunit via grunt-contrib-watch with process spawning disabled. In this environment, any tasks that invoke nodeunit will share a context - and more importantly, a module cache. As such, tests will fail after the first pass.