### PR TITLE
Fix error when hiding stack trace

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -205,6 +205,8 @@ exports.betterErrors = function (assertion) {
         );
         var spacing = (multiline ? '\n' : ' ');
         e._message = e.message;
+        // avoids error when stack trace is hidden with Error.stackTraceLimit
+        e.stack = e.stack || '';
         e.stack = (
             e.name + ':' + spacing +
             actual + spacing + e.operator + spacing +


### PR DESCRIPTION
Fixes error when stack trace is hidden with `Error.stackTraceLimit = 0`
Potentially provides a fix to #64

The error message: 

```
nodeunit/lib/utils.js:212
            e.stack.split('\n').slice(1).join('\n')
                    ^
TypeError: Cannot call method 'split' of undefined
```
