### PR TITLE
Fix for invalid generated html (causes exceptions in xhtml)

### DIFF
--- a/lib/reporters/browser.js
+++ b/lib/reporters/browser.js
@@ -114,7 +114,7 @@ exports.run = function (modules, options, callback) {
             result.innerHTML = 'Tests completed in ' + duration +
                 ' milliseconds.<br/><span class="passed">' +
                 assertions.passes() + '</span> assertions of ' +
-                '<span class="all">' + assertions.length + '<span> passed, ' +
+                '<span class="all">' + assertions.length + '</span> passed, ' +
                 assertions.failures() + ' failed.';
 
             if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);

--- a/lib/reporters/browser.js
+++ b/lib/reporters/browser.js
@@ -73,11 +73,12 @@ exports.run = function (modules, options, callback) {
         testDone: function (name, assertions) {
             var test = document.createElement('li');
             var strong = document.createElement('strong');
-            strong.innerHTML = name + ' <b style="color: black;">(' +
+            strong.appendChild(document.createTextNode(name));
+            strong.insertAdjacentHTML('beforeend', ' <b style="color: black;">(' +
                 '<b class="fail">' + assertions.failures() + '</b>, ' +
                 '<b class="pass">' + assertions.passes() + '</b>, ' +
                 assertions.length +
-            ')</b>';
+            ')</b>');
             test.className = assertions.failures() ? 'fail': 'pass';
             test.appendChild(strong);
 
@@ -91,12 +92,14 @@ exports.run = function (modules, options, callback) {
                 var li = document.createElement('li');
                 var a = assertions[i];
                 if (a.failed()) {
-                    li.innerHTML = (a.message || a.method || 'no message') +
-                        '<pre>' + (a.error.stack || a.error) + '</pre>';
+                    li.textContent = a.message || a.method || 'no message';
+                    var pre = document.createElement('pre');
+                    pre.textContent = a.error.stack || a.error;
+                    li.appendChild(pre);
                     li.className = 'fail';
                 }
                 else {
-                    li.innerHTML = a.message || a.method || 'no message';
+                    li.textContent = a.message || a.method || 'no message';
                     li.className = 'pass';
                 }
                 aList.appendChild(li);


### PR DESCRIPTION
Without this fix nodeunit does not function properly when running in a browser using a xhtml mimetype.