### PR TITLE
catch exceptions that occur when printing test failures

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -86,10 +86,30 @@ assert.AssertionError.prototype.toString = function() {
   if (this.message) {
     return [this.name+":", this.message].join(' ');
   } else {
+    var expectedString;
+    try {
+      expectedString = (typeof this.expected !== 'undefined'
+                        ? JSON.stringify(this.expected)
+                        : 'undefined');
+    }
+    catch (e) {
+      return this.name + ": JSON.stringify(expected) threw exception: \"" + e + "\"";
+    }
+
+    var actualString;
+    try {
+      actualString = (typeof this.actual !== 'undefined'
+                      ? JSON.stringify(this.actual)
+                      : 'undefined');
+    }
+    catch (e) {
+      return this.name + ": JSON.stringify(actual) threw exception: \"" + e + "\"";
+    }
+
     return [ this.name+":"
-           , typeof this.expected !== 'undefined' ? JSON.stringify(this.expected) : 'undefined'
+           , expectedString
            , this.operator
-           , typeof this.actual !== 'undefined' ? JSON.stringify(this.actual) : 'undefined'
+           , actualString
            ].join(" ");
   }
 };


### PR DESCRIPTION
My specific case involved an object with circular references. When making a call to strictEqual(), I was getting:

TypeError: Converting circular structure to JSON

And then it would crash without running the rest of the tests or displaying the "FAILURES: 8/3136 assertions failed (3792ms)" line.

With this fix, I get a better display, a full stack trace, and the tests keep running.
