### PR TITLE
Enable undone tests tracking for the minimal reporter

### DIFF
--- a/lib/reporters/minimal.js
+++ b/lib/reporters/minimal.js
@@ -12,6 +12,7 @@ var nodeunit = require('../nodeunit'),
     utils = require('../utils'),
     fs = require('fs'),
     path = require('path'),
+    track = require('../track'),
     AssertionError = require('assert').AssertionError;
 
 /**
@@ -52,6 +53,23 @@ exports.run = function (files, options, callback) {
 
     var start = new Date().getTime();
 
+    var tracker = track.createTracker(function (tracker) {
+        if (tracker.unfinished()) {
+            console.log('');
+            console.log(bold(red(
+                'FAILURES: Undone tests (or their setups/teardowns): '
+            )));
+            var names = tracker.names();
+            for (var i = 0; i < names.length; i += 1) {
+                console.log('- ' + names[i]);
+            }
+            console.log('');
+            console.log('To fix this, make sure all tests call test.done()');
+            process.reallyExit(tracker.unfinished());
+        }
+    });
+
+
 	var opts = {
 	    testspec: options.testspec,
 	    testFullSpec: options.testFullSpec,
@@ -76,9 +94,12 @@ exports.run = function (files, options, callback) {
             }
 
         },
-        testStart: function () {
+        testStart: function (name) {
+            tracker.put(name);
         },
         testDone: function (name, assertions) {
+            tracker.remove(name);
+
             if (!assertions.failures()) {
                 process.stdout.write('.');
             }


### PR DESCRIPTION
Currently minimal reporter exits clearly without any error if `test.done()` was not called.