### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,12 +69,7 @@
   "bugs": {
     "url": "http://github.com/caolan/nodeunit/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/caolan/nodeunit/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "directories": {
     "lib": "./lib",
     "doc": "./doc",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/