### PR TITLE
Added recursive flag

### DIFF
--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -29,6 +29,7 @@ var usage = "Usage: nodeunit [options] testmodule1.js testfolder [...] \n" +
             "  --config FILE     the path to a JSON file with options\n" +
             "  --reporter FILE   optional path to a reporter file to customize the output\n" +
             "  --list-reporters  list available build-in reporters\n" +
+            "  -r                recursively run tests in sub-directories\n" +
             "  -t testName,      specify a test to run\n" +
             "  -f fullTestName,  specify a specific test to run. fullTestName is built so: \"outerGroup - .. - innerGroup - testName\"\n"  +
             "  -h, --help        display this help and exit\n" +
@@ -63,6 +64,8 @@ args.forEach(function (arg) {
     } else if (reporter_param_found) {
         reporter_file = arg;
         reporter_param_found = false;
+    } else if (arg === '-r') {
+        options.recursive = true;
     } else if (arg === '-t') {
         testspec_param_found = true;
     } else if (testspec_param_found) {

--- a/lib/nodeunit.js
+++ b/lib/nodeunit.js
@@ -79,7 +79,7 @@ exports.runFiles = function (paths, opt) {
             exports.done()
             options.done(types.assertionList(all_assertions, end - start));
         });
-    });
+    }, options.recursive);
 
 };
 

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -72,6 +72,7 @@ exports.run = function (files, options, callback) {
 	var opts = {
 	    testspec: options.testspec,
 	    testFullSpec: options.testFullSpec,
+        recursive: options.recursive,
         moduleStart: function (name) {
             console.log('\n' + bold(name));
         },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,7 +100,7 @@ exports.modulePaths = function modulePaths(paths, callback, recursive) {
                         // recursively call modulePaths() with sub directories
                         modulePaths(directories, function(err, files) {
                             if (!err) {
-                                cb(null, fullpaths.concat(files))
+                                cb(null, fullpaths.concat(files).sort())
                             } else {
                                 cb(err);
                             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,8 @@ var async = require('../deps/async'),
     fs = require('fs'),
     util = require('util'),
     Script = require('vm').Script,
-    http = require('http');
+    http = require('http'),
+    path = require('path');
 
 
 /**
@@ -52,10 +53,11 @@ extensionPattern = new RegExp('\\.(?:' + extensions.join('|') + ')$');
  *
  * @param {Array} paths
  * @param {Function} callback
+ * @param {Boolean=} recursive
  * @api public
  */
-
-exports.modulePaths = function (paths, callback) {
+exports.modulePaths = function modulePaths(paths, callback, recursive) {
+    recursive = (recursive === true);
     async.concatSeries(paths, function (p, cb) {
         fs.stat(p, function (err, stats) {
             if (err) {
@@ -82,10 +84,35 @@ exports.modulePaths = function (paths, callback) {
                         return [p, mod_name].join('/');
                     });
 
-                    // sort filenames here, because Array.map changes order
-                    fullpaths.sort();
+                    if (recursive) {
+                        // get all sub directories
+                        var directories =
+                            files
+                                .map(function(filename) {
+                                    // resolve path first
+                                    return path.resolve(p, filename);
+                                })
+                                .filter(function(filename) {
+                                    // fetch only directories
+                                    return (fs.statSync(filename).isDirectory());
+                                });
 
-                    cb(null, fullpaths);
+                        // recursively call modulePaths() with sub directories
+                        modulePaths(directories, function(err, files) {
+                            if (!err) {
+                                cb(null, fullpaths.concat(files))
+                            } else {
+                                cb(err);
+                            }
+                        }, recursive);
+                    } else {
+                        // sort filenames here, because Array.map changes order
+                        fullpaths.sort();
+
+                        // finish
+                        cb(null, fullpaths);
+                    }
+
                 });
             }
         });

--- a/test/fixtures/dir/example_test_sub.js
+++ b/test/fixtures/dir/example_test_sub.js
@@ -1,0 +1,4 @@
+exports['example test sub'] = function (test) {
+    test.ok(true);
+    test.done();
+};

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -3,6 +3,7 @@ var exec = require('child_process').exec,
 
 var bin = path.resolve(__dirname, '../bin/nodeunit');
 var testfile_fullpath = path.resolve(__dirname, './fixtures/example_test.js');
+var fixtures_path = path.resolve(__dirname, './fixtures');
 
 exports['run test suite using absolute path'] = function (test) {
     exec(bin + ' ' + testfile_fullpath, function (err, stdout, stderr) {
@@ -11,6 +12,28 @@ exports['run test suite using absolute path'] = function (test) {
         }
         test.ok(/example test/.test(stdout));
         test.ok(/1 assertion/.test(stdout));
+        test.done();
+    });
+};
+
+exports['runs only top-level suites without recursive flag'] = function (test) {
+    exec(bin + ' ' + fixtures_path, function (err, stdout, stderr) {
+        if (err) {
+            return test.done(err);
+        }
+        test.ok(/example test/.test(stdout));
+        test.ok(!/example test sub/.test(stdout));
+        test.done();
+    });
+};
+
+exports['runs top + nested suites with recursive flag'] = function (test) {
+    exec(bin + ' ' + fixtures_path + ' -r', function (err, stdout, stderr) {
+        if (err) {
+            return test.done(err);
+        }
+        test.ok(/example test/.test(stdout));
+        test.ok(/example test sub/.test(stdout));
         test.done();
     });
 };

--- a/test/test-runfiles.js
+++ b/test/test-runfiles.js
@@ -19,7 +19,7 @@ var setup = function (fn) {
 
 
 exports.testRunFiles = setup(function (test) {
-    test.expect(28);
+    test.expect(33);
     var runModule_copy = nodeunit.runModule;
 
     var runModule_calls = [];
@@ -43,7 +43,7 @@ exports.testRunFiles = setup(function (test) {
         },
         done: function (assertions) {
             test.equals(assertions.failures(), 0, 'failures');
-            test.equals(assertions.length, 4, 'length');
+            test.equals(assertions.length, 5, 'length');
             test.ok(typeof assertions.duration === "number");
 
             var called_with = function (name) {
@@ -55,7 +55,7 @@ exports.testRunFiles = setup(function (test) {
             test.ok(called_with('mock_module2'), 'mock_module2 ran');
             test.ok(called_with('mock_module3'), 'mock_module3 ran');
             test.ok(called_with('mock_module4'), 'mock_module4 ran');
-            test.equals(runModule_calls.length, 4);
+            test.equals(runModule_calls.length, 5);
 
             nodeunit.runModule = runModule_copy;
             test.done();


### PR DESCRIPTION
I added support, via a command-line flag, to recursively search and process test files from directories listed as arguments.

Using `nodeunit -r mydir` should recursively search all subdirectories in `mydir`.