### PR TITLE
Process files in order to prevent unresolved dependencies

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,7 +56,7 @@ extensionPattern = new RegExp('\\.(?:' + extensions.join('|') + ')$');
  */
 
 exports.modulePaths = function (paths, callback) {
-    async.concat(paths, function (p, cb) {
+    async.concatSeries(paths, function (p, cb) {
         fs.stat(p, function (err, stats) {
             if (err) {
                 return cb(err);


### PR DESCRIPTION
`nodeunit` is a dependency of `grunt-config-nodeunit` which the [Tessel CLI](https://github.com/tessel/t2-cli) uses to run unit tests.

We hit an issue where [we were loading test files](https://github.com/tessel/t2-cli/blob/master/Gruntfile.js#L12) into Nodeunit but they were being `require`d out of order. This is an issue because the second file relied on data structures created in the first file. 

This happened because the paths to these files are loaded asynchronously prior to the `require` statement. This PR fixes that. 

Fixes https://github.com/caolan/nodeunit/issues/296.