### PR TITLE
#319 Use correct assertionError class in reporters

### DIFF
--- a/lib/reporters/html.js
+++ b/lib/reporters/html.js
@@ -12,7 +12,7 @@ var nodeunit = require('../nodeunit'),
     utils = require('../utils'),
     fs = require('fs'),
     path = require('path'),
-    AssertionError = require('assert').AssertionError;
+    AssertionError = require('../assert').AssertionError;
 
 /**
  * Reporter info string

--- a/lib/reporters/junit.js
+++ b/lib/reporters/junit.js
@@ -13,7 +13,7 @@ var nodeunit = require('../nodeunit'),
     fs = require('fs'),
     path = require('path'),
     async = require('../../deps/async'),
-    AssertionError = require('assert').AssertionError,
+    AssertionError = require('../assert').AssertionError,
     child_process = require('child_process'),
     ejs = require('../../deps/ejs');
 

--- a/lib/reporters/minimal.js
+++ b/lib/reporters/minimal.js
@@ -13,7 +13,7 @@ var nodeunit = require('../nodeunit'),
     fs = require('fs'),
     path = require('path'),
     track = require('../track'),
-    AssertionError = require('assert').AssertionError;
+    AssertionError = require('../assert').AssertionError;
 
 /**
  * Reporter info string

--- a/lib/reporters/skip_passed.js
+++ b/lib/reporters/skip_passed.js
@@ -12,7 +12,7 @@ var nodeunit = require('../nodeunit'),
     utils = require('../utils'),
     fs = require('fs'),
     path = require('path'),
-    AssertionError = require('assert').AssertionError;
+    AssertionError = require('../assert').AssertionError;
 
 /**
  * Reporter info string


### PR DESCRIPTION
The assertionError class was using the node assert module instead of the local lib/assert module, and so the equality test for some reporters was failing.