### PR TITLE
Fixes rendering issue with the Windows console

### DIFF
--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -13,8 +13,7 @@ var nodeunit = require('../nodeunit'),
     fs = require('fs'),
     track = require('../track'),
     path = require('path'),
-    AssertionError = require('../assert').AssertionError,
-    process = require('process');
+    AssertionError = require('../assert').AssertionError;
 
 /**
  * Reporter info string

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -13,7 +13,8 @@ var nodeunit = require('../nodeunit'),
     fs = require('fs'),
     track = require('../track'),
     path = require('path'),
-    AssertionError = require('../assert').AssertionError;
+    AssertionError = require('../assert').AssertionError,
+    process = require('process');
 
 /**
  * Reporter info string
@@ -51,6 +52,8 @@ exports.run = function (files, options, callback) {
     var assertion_message = function (str) {
         return options.assertion_prefix + str + options.assertion_suffix;
     };
+    var pass_indicator = process.platform === 'win32' ? '\u221A' : '✔';
+    var fail_indicator = process.platform === 'win32' ? '\u00D7' : '✖';
 
     var start = new Date().getTime();
     var tracker = track.createTracker(function (tracker) {
@@ -80,10 +83,10 @@ exports.run = function (files, options, callback) {
             tracker.remove(name);
 
             if (!assertions.failures()) {
-                console.log('✔ ' + name);
+                console.log(pass_indicator + ' ' + name);
             }
             else {
-                console.log(error('✖ ' + name) + '\n');
+                console.log(error(fail_indicator + ' ' + name) + '\n');
                 assertions.forEach(function (a) {
                     if (a.failed()) {
                         a = utils.betterErrors(a);

--- a/lib/reporters/nested.js
+++ b/lib/reporters/nested.js
@@ -13,8 +13,7 @@ var nodeunit = require('../nodeunit'),
     fs = require('fs'),
     track = require('../track'),
     path = require('path'),
-    AssertionError = require('../assert').AssertionError,
-    process = require('process');
+    AssertionError = require('../assert').AssertionError;
 
 /**
  * Reporter info string

--- a/lib/reporters/nested.js
+++ b/lib/reporters/nested.js
@@ -13,7 +13,8 @@ var nodeunit = require('../nodeunit'),
     fs = require('fs'),
     track = require('../track'),
     path = require('path'),
-    AssertionError = require('../assert').AssertionError;
+    AssertionError = require('../assert').AssertionError,
+    process = require('process');
 
 /**
  * Reporter info string
@@ -52,6 +53,7 @@ exports.run = function (files, options, callback) {
     var assertion_message = function (str) {
         return options.assertion_prefix + str + options.assertion_suffix;
     };
+    var fail_indicator = process.platform === 'win32' ? '\u00D7' : '✖';
 
     var spaces_per_indent = options.spaces_per_indent || 4;
 
@@ -86,7 +88,7 @@ exports.run = function (files, options, callback) {
     };
 
     var fail_text = function (txt) {
-        return bold(error(txt + " (fail) ✖ "));
+        return bold(error(txt + " (fail) " + fail_indicator + " "));
     };
 
     var status_text = function (txt, status) {

--- a/lib/reporters/skip_passed.js
+++ b/lib/reporters/skip_passed.js
@@ -12,8 +12,7 @@ var nodeunit = require('../nodeunit'),
     utils = require('../utils'),
     fs = require('fs'),
     path = require('path'),
-    AssertionError = require('../assert').AssertionError,
-    process = require('process');
+    AssertionError = require('../assert').AssertionError;
 
 /**
  * Reporter info string

--- a/lib/reporters/skip_passed.js
+++ b/lib/reporters/skip_passed.js
@@ -12,7 +12,8 @@ var nodeunit = require('../nodeunit'),
     utils = require('../utils'),
     fs = require('fs'),
     path = require('path'),
-    AssertionError = require('../assert').AssertionError;
+    AssertionError = require('../assert').AssertionError,
+    process = require('process');
 
 /**
  * Reporter info string
@@ -49,6 +50,8 @@ exports.run = function (files, options, callback) {
     var assertion_message = function (str) {
         return options.assertion_prefix + str + options.assertion_suffix;
     };
+    var pass_indicator = process.platform === 'win32' ? '\u221A' : '✔';
+    var fail_indicator = process.platform === 'win32' ? '\u00D7' : '✖';
 
     var start = new Date().getTime();
     var paths = files.map(function (p) {
@@ -63,7 +66,7 @@ exports.run = function (files, options, callback) {
         },
         testDone: function (name, assertions) {
             if (assertions.failures()) {
-                console.log(error('✖ ' + name) + '\n');
+                console.log(error(fail_indicator + ' ' + name) + '\n');
                 assertions.forEach(function (a) {
                     if (a.failed()) {
                         a = utils.betterErrors(a);
@@ -79,10 +82,10 @@ exports.run = function (files, options, callback) {
         },
         moduleDone: function (name, assertions) {
             if (!assertions.failures()) {
-                console.log('✔ all tests passed');
+                console.log(pass_indicator + ' all tests passed');
             }
             else {
-                console.log(error('✖ some tests failed'));
+                console.log(error(fail_indicator + ' some tests failed'));
             }
         },
         done: function (assertions) {

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -13,7 +13,8 @@ var nodeunit = require('../nodeunit'),
     fs = require('fs'),
     track = require('../track'),
     path = require('path'),
-    AssertionError = require('../assert').AssertionError;
+    AssertionError = require('../assert').AssertionError,
+    process = require('process');
 
 /**
  * Reporter info string
@@ -51,6 +52,8 @@ exports.run = function (files, options, callback) {
     var assertion_message = function (str) {
         return options.assertion_prefix + str + options.assertion_suffix;
     };
+    var pass_indicator = process.platform === 'win32' ? '\u221A' : '✔';
+    var fail_indicator = process.platform === 'win32' ? '\u00D7' : '✖';
 
     var start = new Date().getTime();
     var paths = files.map(function (p) {
@@ -82,20 +85,20 @@ exports.run = function (files, options, callback) {
             tracker.remove(name);
 
             if (!assertions.failures()) {
-                console.log('✔ ' + name);
+                console.log(pass_indicator + ' ' + name);
             }
             else {
-                console.log(error('✖ ' + name));
+                console.log(error(fail_indicator + ' ' + name));
             }
             // verbose so print everything
             assertions.forEach(function (a) {
               if (a.failed()) {
-                console.log(error('  ✖ ' + a.message));
+                console.log(error('  ' + fail_indicator + ' ' + a.message));
                 a = utils.betterErrors(a);
                 console.log('  ' + a.error.stack);
               }
               else {
-                console.log('  ✔ ' + a.message);
+                console.log('  ' + pass_indicator + ' ' + a.message);
               }
             });
         },

--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -13,8 +13,7 @@ var nodeunit = require('../nodeunit'),
     fs = require('fs'),
     track = require('../track'),
     path = require('path'),
-    AssertionError = require('../assert').AssertionError,
-    process = require('process');
+    AssertionError = require('../assert').AssertionError;
 
 /**
  * Reporter info string


### PR DESCRIPTION
Resolves #298 

I made this as simple as possible.  The fail character is just a literal x.

Before:
![nodeunit-before](https://cloud.githubusercontent.com/assets/3755379/18318257/04d2862e-74ef-11e6-8346-d96d9b7f0bc2.PNG)

After:
![nodeunit-after](https://cloud.githubusercontent.com/assets/3755379/18318258/07267ed0-74ef-11e6-99dd-2065251372d9.PNG)
