### PR TITLE
Fix external tests on Windows

### DIFF
--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,6 +1,5 @@
 var exec = require('child_process').exec,
-    path = require('path'),
-    process = require('process');
+    path = require('path');
 
 var bin = (process.platform === 'win32' ? 'node ' : "") +
     path.resolve(__dirname, '../bin/nodeunit');

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,7 +1,9 @@
 var exec = require('child_process').exec,
-    path = require('path');
+    path = require('path'),
+    process = require('process');
 
-var bin = path.resolve(__dirname, '../bin/nodeunit');
+var bin = (process.platform === 'win32' ? 'node ' : "") +
+    path.resolve(__dirname, '../bin/nodeunit');
 var testfile_fullpath = path.resolve(__dirname, './fixtures/example_test.js');
 var fixtures_path = path.resolve(__dirname, './fixtures');
 


### PR DESCRIPTION
Currently the test-cli tests fail on Windows.  Have to call `node` explicitly on this platform.  With this fix, all tests pass.