### PR TITLE
Allow invoking browser `run()` without options

### DIFF
--- a/examples/browser/nodeunit.js
+++ b/examples/browser/nodeunit.js
@@ -1940,6 +1940,7 @@ exports.info = "Browser-based test reporter";
  */
 
 exports.run = function (modules, options) {
+    options = options || {};
     var start = new Date().getTime();
     var textareas = options.textareas;
     var displayErrorsByDefault = options.displayErrorsByDefault;


### PR DESCRIPTION
Apologies, my last PR should have included this.
