### PR TITLE
Explicitly exit out of nodeunit in both success and failure cases

### DIFF
--- a/bin/nodeunit
+++ b/bin/nodeunit
@@ -124,7 +124,5 @@ else {
 }
 
 testrunner.run(files, options, function(err) {
-    if (err) {
-        process.exit(1);
-    }
+    process.exit(err ? 1 : 0);
 });


### PR DESCRIPTION
Connected to issue #330 Don't allow open connection pools to prevent nodeunit from exiting.