### PR TITLE
mentioned npm dependencies in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ nodeunit functionality is available.
 
 To run the nodeunit tests do:
 
+    npm install ejs should
     make test
 
 __Note:__ There was a bug in node v0.2.0 causing the tests to hang, upgrading


### PR DESCRIPTION
A workaround for #351. 

I'd still like to see the Makescript install `ejs` and `should`, but now that the readme lists these, it's not urgent.