### PR TITLE
WIP add coffeescript to coffee extension detection

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,12 +17,17 @@ var async = require('../deps/async'),
 
 
 /**
- * Detect if coffee-script, iced-coffeescript, or streamline are available and 
+ * Detect if coffeescript, coffee-script, iced-coffeescript, or streamline are available and
  * the respective file extensions to the search filter in modulePaths if it is.
  */
 
 var extensions = [ 'js' ];  // js is always supported: add it unconditionally
 var extensionPattern;
+
+try {
+    require('coffee' + 'script/register');
+    extensions.push('coffee');
+} catch (e) { }
 
 try {
     require('coffee' + '-script/register');


### PR DESCRIPTION
CoffeeScript on NPM has moved to coffeescript (no hyphen)
https://www.npmjs.com/package/coffee-script

Before

```bash
$ yarn link nodeunit
yarn link v1.19.1
success Using linked package for "nodeunit".
✨  Done in 0.07s.
$ npm test

> eco@1.1.0-rc-3 test /Users/gchiodo/git/eco
> nodeunit


OK: 0 assertions (1ms)
```

After (still not working)

```
$ npm test

> eco@1.1.0-rc-3 test ~/eco
> nodeunit

e Error: Cannot find module 'coffeescript'
Require stack:
- ~/nodeunit/lib/utils.js
- ~/nodeunit/lib/nodeunit.js
- ~/nodeunit/lib/reporters/tap.js
- ~/nodeunit/lib/reporters/index.js
- ~/nodeunit/bin/nodeunit
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:797:15)
    at Function.Module._load (internal/modules/cjs/loader.js:690:27)
    at Module.require (internal/modules/cjs/loader.js:852:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (~/nodeunit/lib/utils.js:28:20)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Module.require (internal/modules/cjs/loader.js:852:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '~/nodeunit/lib/utils.js',
    '~/nodeunit/lib/nodeunit.js',
    '~/nodeunit/lib/reporters/tap.js',
    '~/nodeunit/lib/reporters/index.js',
    '~/nodeunit/bin/nodeunit'
  ]
}
```