### PR TITLE
fix travis for node  0.12: lock ejs to before `let` was introduced

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "nodeunit": "./bin/nodeunit"
   },
   "dependencies": {
-    "ejs": "^2.5.2",
+    "ejs": "2.7.2",
     "tap": "^12.0.1"
   },
   "scripts": {


### PR DESCRIPTION
# Steps to reproduce

Before https://travis-ci.org/github/caolan/nodeunit/builds/710077144

<img width="879" alt="Screen Shot 2020-07-20 at 1 48 04 PM" src="https://user-images.githubusercontent.com/196199/87969239-be4be380-ca8f-11ea-90a3-930afd92203e.png">


https://travis-ci.org/github/caolan/nodeunit/jobs/710077156

$ npm install 
> ejs@2.7.4 postinstall /home/travis/build/caolan/nodeunit/node_modules/ejs
> node ./postinstall.js
/home/travis/build/caolan/nodeunit/node_modules/ejs/postinstall.js:9
let envDisable = isTrue(process.env.DISABLE_OPENCOLLECTIVE) || isTrue(process.
^^^
SyntaxError: Unexpected strict mode reserved word
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3

After https://travis-ci.org/github/caolan/nodeunit/builds/710097661

<img width="856" alt="Screen Shot 2020-07-20 at 1 48 19 PM" src="https://user-images.githubusercontent.com/196199/87969230-b8560280-ca8f-11ea-86c1-647870d62d19.png">


# Root cause

https://github.com/mde/ejs/compare/v2.7.2...v2.7.3 introduced a `let` before `ejs@3.x` dropped support for older node versions 
